### PR TITLE
Fix wide-character and input method text entry in the TUI

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -113,10 +113,14 @@ fn loading_frame(started_at: Instant) -> &'static str {
     frames[(elapsed / 120) % frames.len()]
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct WidgetState {
     pub(crate) inline_image_placements: Vec<crate::tui::ui::DetailInlineImagePlacement>,
     pub(crate) detail_document: Option<std::rc::Rc<crate::tui::ui::DetailDocument>>,
+    /// Cell holding the caret of the focused text input in the last rendered
+    /// frame, parked on the terminal cursor after every draw so IME preedit
+    /// text appears where the user is typing.
+    pub(crate) text_cursor: Option<ratatui::layout::Position>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -272,10 +276,7 @@ impl App {
             should_quit: false,
             list: ListSurface::new(has_tasks),
             intake: IntakeController::new(),
-            widgets: WidgetState {
-                inline_image_placements: Vec::new(),
-                detail_document: None,
-            },
+            widgets: WidgetState::default(),
             overlay: None,
             onboarding_intro: None,
             notification: None,

--- a/src/tui/app_lifecycle.rs
+++ b/src/tui/app_lifecycle.rs
@@ -41,6 +41,31 @@ fn event_after_queued_wheel(direction: MouseEventKind) -> Result<Option<Event>> 
 }
 
 impl App {
+    /// Renders one frame and leaves the terminal cursor on the caret of the
+    /// focused text input.
+    ///
+    /// The TUI paints its own cursor cell, so Ratatui hides the terminal cursor
+    /// and would otherwise leave it wherever the buffer diff stopped writing.
+    /// Input method editors draw their in-progress composition at the terminal
+    /// cursor, so Korean, Japanese, and Chinese preedit text would appear at an
+    /// unrelated cell instead of at the caret.
+    fn draw(&mut self, terminal: &mut DefaultTerminal) -> Result<()> {
+        let view = self.view();
+        terminal.draw(|frame| {
+            ui::render(frame, &self.store, &mut self.widgets, &mut self.list, &view)
+        })?;
+        self.park_terminal_cursor(terminal);
+        Ok(())
+    }
+
+    /// Moves the hidden terminal cursor onto the last rendered caret. Called
+    /// again after inline image emission because those writes move the cursor.
+    fn park_terminal_cursor(&self, terminal: &mut DefaultTerminal) {
+        if let Some(position) = self.widgets.text_cursor {
+            let _ = terminal.set_cursor_position(position);
+        }
+    }
+
     pub(crate) async fn run(mut self, terminal: &mut DefaultTerminal) -> Result<()> {
         execute!(std::io::stdout(), EnableBracketedPaste, EnableMouseCapture)?;
         let result = self.run_loop(terminal).await;
@@ -131,11 +156,9 @@ impl App {
             }
 
             if needs_redraw {
-                let view = self.view();
-                terminal.draw(|frame| {
-                    ui::render(frame, &self.store, &mut self.widgets, &mut self.list, &view)
-                })?;
+                self.draw(terminal)?;
                 needs_redraw = self.render_inline_images_after_draw(terminal).is_err();
+                self.park_terminal_cursor(terminal);
             }
 
             let timeout = self.next_poll_timeout();
@@ -240,10 +263,7 @@ impl App {
         self.inline_images.reconcile_displayed(&current, backend);
 
         if repaint {
-            let view = self.view();
-            terminal.draw(|frame| {
-                ui::render(frame, &self.store, &mut self.widgets, &mut self.list, &view)
-            })?;
+            self.draw(terminal)?;
         }
         if backend == InlineImageBackend::None {
             return Ok(());
@@ -282,10 +302,7 @@ impl App {
             ) {
                 let repaint = self.erase_previous_inline_images().unwrap_or(false);
                 if repaint {
-                    let view = self.view();
-                    let _ = terminal.draw(|frame| {
-                        ui::render(frame, &self.store, &mut self.widgets, &mut self.list, &view)
-                    });
+                    let _ = self.draw(terminal);
                 }
                 return Err(error.into());
             }
@@ -293,10 +310,7 @@ impl App {
         if let Err(error) = stdout.flush() {
             let repaint = self.erase_previous_inline_images().unwrap_or(false);
             if repaint {
-                let view = self.view();
-                let _ = terminal.draw(|frame| {
-                    ui::render(frame, &self.store, &mut self.widgets, &mut self.list, &view)
-                });
+                let _ = self.draw(terminal);
             }
             return Err(error.into());
         }

--- a/src/tui/app_tests/authoring.rs
+++ b/src/tui/app_tests/authoring.rs
@@ -2162,3 +2162,30 @@ async fn add_note_flow_creates_note_for_selected_task() {
     assert!(app.overlay.is_none());
     assert!(toast_message(&app).is_some_and(|message| message.starts_with("added note ")));
 }
+
+#[tokio::test]
+async fn add_task_reports_title_caret_to_terminal_cursor() {
+    let mut app = test_app().await;
+    app.handle_normal_key(KeyCode::Char('a')).await.unwrap();
+    type_chars(&mut app, "ab").await;
+
+    let buffer = render_app_buffer(&mut app, 120, 30);
+    let cursor = app.widgets.text_cursor.expect("caret reported");
+
+    assert_eq!(buffer[(cursor.x, cursor.y)].symbol(), " ");
+    assert_eq!(buffer[(cursor.x - 2, cursor.y)].symbol(), "a");
+    assert_eq!(buffer[(cursor.x - 1, cursor.y)].symbol(), "b");
+}
+
+#[tokio::test]
+async fn add_task_caret_follows_wide_characters() {
+    let mut app = test_app().await;
+    app.handle_normal_key(KeyCode::Char('a')).await.unwrap();
+    type_chars(&mut app, "한글").await;
+
+    let buffer = render_app_buffer(&mut app, 120, 30);
+    let cursor = app.widgets.text_cursor.expect("caret reported");
+
+    assert_eq!(buffer[(cursor.x - 4, cursor.y)].symbol(), "한");
+    assert_eq!(buffer[(cursor.x - 2, cursor.y)].symbol(), "글");
+}

--- a/src/tui/app_tests/authoring.rs
+++ b/src/tui/app_tests/authoring.rs
@@ -2189,3 +2189,23 @@ async fn add_task_caret_follows_wide_characters() {
     assert_eq!(buffer[(cursor.x - 4, cursor.y)].symbol(), "한");
     assert_eq!(buffer[(cursor.x - 2, cursor.y)].symbol(), "글");
 }
+
+#[tokio::test]
+async fn add_task_title_scrolls_wide_characters_within_the_dialog() {
+    let mut app = test_app().await;
+    app.handle_normal_key(KeyCode::Char('a')).await.unwrap();
+    type_chars(&mut app, &"한".repeat(80)).await;
+
+    let buffer = render_app_buffer(&mut app, 100, 30);
+    let cursor = app.widgets.text_cursor.expect("caret reported");
+    let caret_row = (0..buffer.area.width)
+        .map(|column| buffer[(column, cursor.y)].symbol())
+        .collect::<String>();
+
+    assert!(cursor.x < buffer.area.width, "caret stayed on screen");
+    assert_eq!(buffer[(cursor.x - 2, cursor.y)].symbol(), "한");
+    assert!(
+        caret_row.matches('한').count() < 80,
+        "title scrolled instead of overflowing: {caret_row:?}"
+    );
+}

--- a/src/tui/overlay/layout.rs
+++ b/src/tui/overlay/layout.rs
@@ -1,7 +1,7 @@
 use ratatui::layout::{Constraint, Flex, Layout, Rect, Size};
 use ratatui::widgets::{Block, Borders, Padding};
 
-use crate::tui::text::char_count_ranges;
+use crate::tui::text::cell_width_ranges;
 
 use super::{PickerKind, PickerMode, PickerView, TagComboboxView, picker_viewport_start};
 
@@ -162,7 +162,7 @@ fn picker_visible_start(state: &PickerView, viewport_rows: usize) -> usize {
 
 pub(crate) fn confirm_layout(terminal_size: Size, prompt: &str) -> ConfirmLayout {
     let width = confirm_width(terminal_size.width, prompt);
-    let prompt_rows = char_count_ranges(prompt, width.saturating_sub(4) as usize).len();
+    let prompt_rows = cell_width_ranges(prompt, width.saturating_sub(4) as usize).len();
     let height = prompt_rows.saturating_add(4) as u16;
     let area = dialog_area(
         Rect::new(0, 0, terminal_size.width, terminal_size.height),

--- a/src/tui/text.rs
+++ b/src/tui/text.rs
@@ -56,6 +56,16 @@ pub(crate) fn next_char_is_whitespace(input: &str, index: usize) -> bool {
         .is_some_and(char::is_whitespace)
 }
 
+/// Terminal cells one character occupies. Zero-width characters still claim one
+/// cell so every character stays addressable by the cursor.
+pub(crate) fn char_cells(ch: char) -> usize {
+    ch.width().unwrap_or(0).max(1)
+}
+
+pub(crate) fn str_cells(text: &str) -> usize {
+    text.chars().map(char_cells).sum()
+}
+
 pub(crate) fn cell_width_ranges(line: &str, width: usize) -> Vec<(usize, usize)> {
     if line.is_empty() {
         return vec![(0, 0)];
@@ -65,7 +75,7 @@ pub(crate) fn cell_width_ranges(line: &str, width: usize) -> Vec<(usize, usize)>
     let mut start = 0;
     let mut count = 0;
     for (index, ch) in line.char_indices() {
-        let char_width = ch.width().unwrap_or(0).max(1);
+        let char_width = char_cells(ch);
         if count > 0 && count + char_width > width {
             ranges.push((start, index));
             start = index;
@@ -77,39 +87,46 @@ pub(crate) fn cell_width_ranges(line: &str, width: usize) -> Vec<(usize, usize)>
     ranges
 }
 
-pub(crate) fn char_count_ranges(line: &str, width: usize) -> Vec<(usize, usize)> {
-    let width = width.max(1);
-    let mut boundaries = line
-        .char_indices()
-        .map(|(index, _)| index)
-        .collect::<Vec<_>>();
-    boundaries.push(line.len());
-    let char_count = boundaries.len().saturating_sub(1);
-    if char_count == 0 {
-        return vec![(0, 0)];
-    }
-    (0..char_count)
-        .step_by(width)
-        .map(|start| {
-            let end = start.saturating_add(width).min(char_count);
-            (boundaries[start], boundaries[end])
-        })
-        .collect()
+pub(crate) fn segment_index_at(ranges: &[(usize, usize)], cursor: usize) -> usize {
+    ranges
+        .iter()
+        .position(|(start, end)| cursor < *end || (*start == *end && cursor == *start))
+        .unwrap_or_else(|| ranges.len().saturating_sub(1))
 }
 
-pub(crate) fn char_count_segment_index(line: &str, cursor: usize, width: usize) -> usize {
-    let width = width.max(1);
+pub(crate) fn cell_width_segment_index(line: &str, cursor: usize, width: usize) -> usize {
     let cursor = char_boundary_at_or_before(line, cursor);
-    let cursor_chars = line[..cursor].chars().count();
-    let line_chars = line.chars().count();
-    if line_chars == 0 {
-        return 0;
+    segment_index_at(&cell_width_ranges(line, width), cursor)
+}
+
+/// Longest prefix of `text` that fits in `width` cells. Characters that would
+/// straddle the budget are dropped whole so a wide character never renders as
+/// half a cell.
+pub(crate) fn take_leading_cells(text: &str, width: usize) -> &str {
+    let mut used = 0;
+    for (index, ch) in text.char_indices() {
+        let char_width = char_cells(ch);
+        if used + char_width > width {
+            return &text[..index];
+        }
+        used += char_width;
     }
-    if cursor_chars == line_chars {
-        line_chars.saturating_sub(1) / width
-    } else {
-        cursor_chars / width
+    text
+}
+
+/// Longest suffix of `text` that fits in `width` cells.
+pub(crate) fn take_trailing_cells(text: &str, width: usize) -> &str {
+    let mut used = 0;
+    let mut start = text.len();
+    for (index, ch) in text.char_indices().rev() {
+        let char_width = char_cells(ch);
+        if used + char_width > width {
+            break;
+        }
+        used += char_width;
+        start = index;
     }
+    &text[start..]
 }
 
 #[cfg(test)]
@@ -145,18 +162,27 @@ mod tests {
     }
 
     #[test]
-    fn char_count_ranges_keep_valid_boundaries() {
-        let line = "aé中b";
-        assert_eq!(char_count_ranges(line, 2), vec![(0, 3), (3, 7)]);
-        for (start, end) in char_count_ranges(line, 2) {
-            assert!(line.is_char_boundary(start));
-            assert!(line.is_char_boundary(end));
-        }
+    fn cell_width_ranges_wrap_wide_characters_by_cells() {
+        let line = "한글";
+        assert_eq!(cell_width_ranges(line, 2), vec![(0, 3), (3, 6)]);
+        assert_eq!(cell_width_ranges(line, 4), vec![(0, 6)]);
     }
 
     #[test]
-    fn char_count_segment_index_matches_end_cursor_behavior() {
-        assert_eq!(char_count_segment_index("abcd", 4, 2), 1);
-        assert_eq!(char_count_segment_index("abcd", 2, 2), 1);
+    fn cell_width_segment_index_matches_end_cursor_behavior() {
+        assert_eq!(cell_width_segment_index("abcd", 4, 2), 1);
+        assert_eq!(cell_width_segment_index("abcd", 2, 2), 1);
+        assert_eq!(cell_width_segment_index("한글", "한글".len(), 2), 1);
+        assert_eq!(cell_width_segment_index("한글", 3, 2), 1);
+        assert_eq!(cell_width_segment_index("한글", 0, 2), 0);
+    }
+
+    #[test]
+    fn cell_takes_never_split_wide_characters() {
+        assert_eq!(take_leading_cells("한글", 3), "한");
+        assert_eq!(take_leading_cells("한글", 4), "한글");
+        assert_eq!(take_trailing_cells("한글", 3), "글");
+        assert_eq!(take_trailing_cells("한글", 1), "");
+        assert_eq!(take_trailing_cells("abc", 2), "bc");
     }
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -196,6 +196,17 @@ pub(crate) fn render(
     list: &mut ListSurface,
     view: &ViewState,
 ) {
+    render_surface(frame, store, widgets, list, view);
+    widgets.text_cursor = self::input::text_cursor_position(frame.buffer_mut());
+}
+
+fn render_surface(
+    frame: &mut Frame,
+    store: &TuiStore,
+    widgets: &mut WidgetState,
+    list: &mut ListSurface,
+    view: &ViewState,
+) {
     widgets.inline_image_placements.clear();
     frame.render_widget(Block::new().style(Style::new().bg(BG)), frame.area());
 

--- a/src/tui/ui/columns.rs
+++ b/src/tui/ui/columns.rs
@@ -10,11 +10,12 @@ use crate::tui::app::Focus;
 use crate::tui::columns::ColumnBoard;
 use crate::tui::overlay::TextInputView;
 use crate::tui::store::TuiStore;
+use crate::tui::text::str_cells;
 use crate::tui::theme::{
     self, ACCENT, BG, BG_ALT, BG_LANE, BG_LANE_ACTIVE, BG_PANEL, BORDER, FG, FG_DIM, FG_MUTED,
     LANE_DIVIDER, ORANGE, RED, SELECTED_BG, YELLOW,
 };
-use crate::tui::ui::truncate::{truncate_chars, truncate_width};
+use crate::tui::ui::truncate::truncate_width;
 use crate::tui::widgets::priority_short;
 use unicode_width::UnicodeWidthStr;
 
@@ -387,12 +388,12 @@ fn card_title_lines(title: &str, max_width: usize) -> Vec<Line<'static>> {
     let mut lines = [String::new(), String::new()];
     for line in &mut lines {
         while let Some(word) = words.peek().copied() {
-            let needed = usize::from(!line.is_empty()) + word.chars().count();
-            if !line.is_empty() && line.chars().count() + needed > max_width {
+            let needed = usize::from(!line.is_empty()) + str_cells(word);
+            if !line.is_empty() && str_cells(line) + needed > max_width {
                 break;
             }
-            if line.is_empty() && word.chars().count() > max_width {
-                *line = truncate_chars(word, max_width);
+            if line.is_empty() && str_cells(word) > max_width {
+                *line = truncate_width(word, max_width);
                 words.next();
                 break;
             }
@@ -404,7 +405,7 @@ fn card_title_lines(title: &str, max_width: usize) -> Vec<Line<'static>> {
         }
     }
     if words.peek().is_some() {
-        lines[1] = truncate_chars(&format!("{} …", lines[1]), max_width);
+        lines[1] = truncate_width(&format!("{} …", lines[1]), max_width);
     }
     lines
         .into_iter()

--- a/src/tui/ui/detail.rs
+++ b/src/tui/ui/detail.rs
@@ -4746,10 +4746,7 @@ mod tests {
             }],
             interactive_rows: Vec::new(),
         };
-        let mut widgets = WidgetState {
-            inline_image_placements: Vec::new(),
-            detail_document: None,
-        };
+        let mut widgets = WidgetState::default();
         let backend = TestBackend::new(20, 5);
         let mut terminal = Terminal::new(backend).unwrap();
 
@@ -4929,10 +4926,7 @@ mod tests {
         item.task.description = String::new();
         item.attachments = vec![attachment_metadata("ATTACHMENT000001", false, true)];
         let context = DetailInlineImageContext::default();
-        let mut widgets = WidgetState {
-            inline_image_placements: Vec::new(),
-            detail_document: None,
-        };
+        let mut widgets = WidgetState::default();
         let backend = TestBackend::new(100, 30);
         let mut terminal = Terminal::new(backend).unwrap();
 

--- a/src/tui/ui/dialog.rs
+++ b/src/tui/ui/dialog.rs
@@ -4,7 +4,7 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph, Wrap};
 
-use super::truncate::truncate_chars;
+use super::truncate::truncate_width;
 use crate::tui::overlay::dialog_area;
 use crate::tui::theme::{ACCENT, BG_ALT, FG, FG_MUTED};
 
@@ -77,7 +77,7 @@ fn overlay_block(title: &str, width: u16) -> Block<'_> {
 }
 
 fn edge_title(title: &str, width: u16) -> Line<'_> {
-    let title = truncate_chars(title, width.saturating_sub(5) as usize);
+    let title = truncate_width(title, width.saturating_sub(5) as usize);
     Line::from(vec![
         Span::styled("─ ", Style::new().fg(ACCENT)),
         Span::raw(title),

--- a/src/tui/ui/input.rs
+++ b/src/tui/ui/input.rs
@@ -1,6 +1,8 @@
 use std::borrow::Cow;
 
-use ratatui::style::Style;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Position;
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 
 use crate::tui::text::char_boundary_at_or_before;
@@ -85,8 +87,33 @@ pub(in crate::tui::ui) fn input_cursor_spans(
     ]
 }
 
+/// Style of the drawn cursor cell. [`text_cursor_position`] locates the caret by
+/// this exact foreground/background pair, so nothing else may use it.
+pub(in crate::tui::ui) const CURSOR_STYLE: Style = Style::new().fg(BG_ALT).bg(FG);
+
 pub(in crate::tui::ui) fn cursor_cell(content: impl Into<Cow<'static, str>>) -> Span<'static> {
-    Span::styled(content, Style::new().fg(BG_ALT).bg(FG))
+    Span::styled(content, CURSOR_STYLE)
+}
+
+/// Finds the drawn cursor cell in a rendered frame so the caller can park the
+/// real terminal cursor there.
+///
+/// The TUI paints its own cursor instead of using the terminal cursor, which
+/// leaves the terminal cursor wherever the last buffer diff happened. Input
+/// method editors (Korean, Japanese, Chinese) draw their in-progress
+/// composition at the terminal cursor, so without this the preedit text appears
+/// somewhere unrelated to the field being typed into.
+///
+/// Cursor cells dimmed by a stacked dialog are ignored: only the caret of the
+/// topmost, active input qualifies.
+pub(crate) fn text_cursor_position(buffer: &Buffer) -> Option<Position> {
+    let index = buffer.content().iter().position(|cell| {
+        Some(cell.fg) == CURSOR_STYLE.fg
+            && Some(cell.bg) == CURSOR_STYLE.bg
+            && !cell.modifier.contains(Modifier::DIM)
+    })?;
+    let (x, y) = buffer.pos_of(index);
+    Some(Position { x, y })
 }
 
 #[cfg(test)]

--- a/src/tui/ui/input.rs
+++ b/src/tui/ui/input.rs
@@ -5,7 +5,9 @@ use ratatui::layout::Position;
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 
-use crate::tui::text::char_boundary_at_or_before;
+use crate::tui::text::{
+    char_boundary_at_or_before, char_cells, str_cells, take_leading_cells, take_trailing_cells,
+};
 use crate::tui::theme::{BG_ALT, FG};
 
 pub(in crate::tui::ui) fn input_line(
@@ -47,43 +49,36 @@ pub(in crate::tui::ui) enum InputWidth {
     Clipped(usize),
 }
 
+/// Builds the spans for a single input row, scrolled so the cursor stays
+/// visible. Every budget is counted in terminal cells, not characters, so wide
+/// characters (CJK, emoji) neither overflow the field nor push the cursor out of
+/// view.
 pub(in crate::tui::ui) fn input_cursor_spans(
     input: &str,
     cursor: usize,
     width: InputWidth,
 ) -> Vec<Span<'static>> {
     let cursor = char_boundary_at_or_before(input, cursor);
-    let input_chars = input.chars().count();
+    let cursor_char = input[cursor..].chars().next();
+    let cursor_cells = cursor_char.map_or(1, char_cells);
     let max_width = match width {
-        InputWidth::Full => input_chars.saturating_add(1),
+        InputWidth::Full => str_cells(input).saturating_add(cursor_cells),
         InputWidth::Clipped(width) => width,
     };
-    let Some(cursor_char) = input[cursor..].chars().next() else {
-        let before = input
-            .chars()
-            .skip(input_chars.saturating_sub(max_width.saturating_sub(1)))
-            .collect::<String>();
-        return vec![Span::raw(before), cursor_cell(" ")];
+    let Some(cursor_char) = cursor_char else {
+        let before = take_trailing_cells(input, max_width.saturating_sub(1));
+        return vec![Span::raw(before.to_string()), cursor_cell(" ")];
     };
-    let cursor_end = cursor + cursor_char.len_utf8();
-    let before = &input[..cursor];
-    let after = &input[cursor_end..];
-    let after_chars = after.chars().count();
-    let value_width = input_chars.saturating_add(1).min(max_width);
-    let before_visible = value_width.saturating_sub(1 + after_chars);
-    let before = before
-        .chars()
-        .skip(before.chars().count().saturating_sub(before_visible))
-        .collect::<String>();
+    let after_budget = max_width.saturating_sub(cursor_cells);
+    let after = take_leading_cells(&input[cursor + cursor_char.len_utf8()..], after_budget);
+    let before = take_trailing_cells(
+        &input[..cursor],
+        after_budget.saturating_sub(str_cells(after)),
+    );
     vec![
-        Span::raw(before),
+        Span::raw(before.to_string()),
         cursor_cell(cursor_char.to_string()),
-        Span::raw(
-            after
-                .chars()
-                .take(max_width.saturating_sub(1))
-                .collect::<String>(),
-        ),
+        Span::raw(after.to_string()),
     ]
 }
 
@@ -159,6 +154,31 @@ mod tests {
         assert_eq!(line.spans[0].content.as_ref(), "aé");
         assert_eq!(line.spans[1].content.as_ref(), "z");
         assert_eq!(line.spans[1].style.bg, Some(FG));
+    }
+
+    #[test]
+    fn clipped_input_line_budgets_wide_characters_by_cells() {
+        let line = clipped_input_line("한글입력", "한글입력".len(), 6);
+        assert_eq!(line.spans[0].content.as_ref(), "입력");
+        assert_eq!(line.spans[1].content.as_ref(), " ");
+        assert!(line.width() <= 6);
+    }
+
+    #[test]
+    fn clipped_input_line_keeps_wide_cursor_visible() {
+        let line = clipped_input_line("한글입력", 3, 4);
+        assert_eq!(line.spans[0].content.as_ref(), "");
+        assert_eq!(line.spans[1].content.as_ref(), "글");
+        assert_eq!(line.spans[2].content.as_ref(), "입");
+        assert!(line.width() <= 4);
+    }
+
+    #[test]
+    fn input_line_keeps_full_width_value_unclipped() {
+        let line = input_line("", "한글", 3);
+        assert_eq!(line.spans[0].content.as_ref(), "한");
+        assert_eq!(line.spans[1].content.as_ref(), "글");
+        assert_eq!(line.spans[2].content.as_ref(), "");
     }
 
     #[test]

--- a/src/tui/ui/overlays/add_task.rs
+++ b/src/tui/ui/overlays/add_task.rs
@@ -8,7 +8,7 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 use super::super::dialog::{Dialog, dialog_hint_line, dim_rendered_area};
 use super::super::input::{clipped_input_line, cursor_cell};
 use super::super::scroll::{clamp_scroll_start, render_vertical_scrollbar};
-use super::super::truncate::truncate_chars;
+use super::super::truncate::truncate_width;
 use super::confirm::render_confirm;
 use super::multiline::add_task_description_input_line;
 use super::picker::{
@@ -1345,28 +1345,28 @@ pub(in crate::tui::ui) fn add_task_metadata_title(
     if width < 60 {
         return Line::from(vec![
             Span::styled(" status: ", Style::new().fg(FG_MUTED)),
-            Span::styled(truncate_chars(status, 8), status_style),
+            Span::styled(truncate_width(status, 8), status_style),
             Span::styled(" · ", Style::new().fg(FG_DIM)),
             Span::styled("prio: ", Style::new().fg(FG_MUTED)),
-            Span::styled(truncate_chars(priority, 6), priority_style),
+            Span::styled(truncate_width(priority, 6), priority_style),
         ]);
     }
     let value_width = (width as usize).saturating_sub(44).max(6) / 4;
     Line::from(vec![
         Span::styled(" project: ", Style::new().fg(FG_MUTED)),
         Span::styled(
-            truncate_chars(project, value_width),
+            truncate_width(project, value_width),
             Style::new().fg(theme::project_color(project)),
         ),
         Span::styled(" · ", Style::new().fg(FG_DIM)),
         Span::styled("status: ", Style::new().fg(FG_MUTED)),
-        Span::styled(truncate_chars(status, value_width), status_style),
+        Span::styled(truncate_width(status, value_width), status_style),
         Span::styled(" · ", Style::new().fg(FG_DIM)),
         Span::styled("prio: ", Style::new().fg(FG_MUTED)),
-        Span::styled(truncate_chars(priority, value_width), priority_style),
+        Span::styled(truncate_width(priority, value_width), priority_style),
         Span::styled(" · ", Style::new().fg(FG_DIM)),
         Span::styled("labels: ", Style::new().fg(FG_MUTED)),
-        Span::styled(truncate_chars(&labels, value_width), label_style),
+        Span::styled(truncate_width(&labels, value_width), label_style),
     ])
 }
 

--- a/src/tui/ui/overlays/confirm.rs
+++ b/src/tui/ui/overlays/confirm.rs
@@ -3,7 +3,7 @@ use ratatui::text::{Line, Text};
 
 use super::super::dialog::{Dialog, dialog_hint_line};
 use crate::tui::overlay::{ConfirmView, confirm_width};
-use crate::tui::text::char_count_ranges;
+use crate::tui::text::cell_width_ranges;
 
 pub(in crate::tui::ui) fn render_confirm(frame: &mut Frame, state: &ConfirmView) {
     render_confirm_with_hint_line(frame, state, confirm_hint_line());
@@ -20,7 +20,7 @@ pub(in crate::tui::ui) fn render_confirm_with_hints(
 fn render_confirm_with_hint_line(frame: &mut Frame, state: &ConfirmView, hints: Line<'static>) {
     let width = confirm_width(frame.area().width, &state.prompt)
         .max(confirm_width(frame.area().width, &hints.to_string()));
-    let prompt_rows = char_count_ranges(&state.prompt, width.saturating_sub(4) as usize).len();
+    let prompt_rows = cell_width_ranges(&state.prompt, width.saturating_sub(4) as usize).len();
     let height = prompt_rows.saturating_add(4) as u16;
     let text = Text::from(vec![
         Line::from(state.prompt.as_str()),

--- a/src/tui/ui/overlays/multiline.rs
+++ b/src/tui/ui/overlays/multiline.rs
@@ -12,7 +12,7 @@ use crate::tui::overlay::{
     ConfirmView, MultilineInputKind, MultilineInputMode, MultilineInputView,
 };
 use crate::tui::text::{
-    cell_width_ranges, char_boundary_at_or_before, char_count_ranges, char_count_segment_index,
+    cell_width_ranges, cell_width_segment_index, char_boundary_at_or_before, segment_index_at,
 };
 use crate::tui::theme::{FG, FG_DIM, FG_MUTED};
 
@@ -151,7 +151,7 @@ pub(in crate::tui::ui) fn description_visual_row_count(
     state
         .lines
         .iter()
-        .map(|line| char_count_ranges(line, line_width).len())
+        .map(|line| cell_width_ranges(line, line_width).len())
         .sum::<usize>()
         .max(1)
 }
@@ -164,10 +164,10 @@ pub(in crate::tui::ui) fn description_editor_lines(
     let mut cursor_row = 0;
     let show_placeholder = state.lines.len() == 1 && state.lines[0].is_empty();
     for (row_index, line) in state.lines.iter().enumerate() {
-        let ranges = char_count_ranges(line, line_width);
+        let ranges = cell_width_ranges(line, line_width);
         if row_index == state.row {
             let cursor = char_boundary_at_or_before(line, state.column);
-            let cursor_segment = char_count_segment_index(line, cursor, line_width);
+            let cursor_segment = cell_width_segment_index(line, cursor, line_width);
             cursor_row = lines.len().saturating_add(cursor_segment);
             for (range_index, (start, end)) in ranges.into_iter().enumerate() {
                 if range_index == cursor_segment {
@@ -303,14 +303,7 @@ fn render_tail_viewport_multiline(
         let ranges = cell_width_ranges(line, line_width);
         let cursor =
             (row_index == state.row).then(|| char_boundary_at_or_before(line, state.column));
-        let cursor_segment = cursor.and_then(|cursor| {
-            ranges
-                .iter()
-                .position(|(range_start, range_end)| {
-                    cursor < *range_end || (*range_start == *range_end && cursor == *range_start)
-                })
-                .or_else(|| ranges.len().checked_sub(1))
-        });
+        let cursor_segment = cursor.map(|cursor| segment_index_at(&ranges, cursor));
         for (range_index, (range_start, range_end)) in ranges.into_iter().enumerate() {
             let segment_cursor = cursor
                 .filter(|_| cursor_segment == Some(range_index))

--- a/src/tui/ui/overlays/search.rs
+++ b/src/tui/ui/overlays/search.rs
@@ -8,7 +8,7 @@ use super::super::dialog::Dialog;
 use super::super::input::{cursor_cell, input_line};
 use super::super::task_display::labels_display;
 use super::super::task_list::EPIC_MARKER;
-use super::super::truncate::truncate_chars;
+use super::super::truncate::truncate_width;
 use crate::query::SearchMatchedField;
 use crate::queue::{now_seconds, unix_seconds};
 use crate::tui::overlay::{SearchKind, SearchResultItem};
@@ -206,7 +206,7 @@ fn result_line(
     let marker = if selected { "▸" } else { " " };
     if result.create_new {
         let title_width = width.saturating_sub(2).max(8);
-        let title = truncate_chars(&result.title, title_width);
+        let title = truncate_width(&result.title, title_width);
         let used_width = 2 + title.chars().count();
         let mut spans = vec![Span::styled(format!("{marker} "), style)];
         spans.extend(title_spans(&title, input, result.matched_field, style));
@@ -221,7 +221,7 @@ fn result_line(
     let title_width = width
         .saturating_sub(ref_width + 4 + epic_marker_width)
         .max(8);
-    let title = truncate_chars(&result.title, title_width);
+    let title = truncate_width(&result.title, title_width);
     let used_width = 2 + ref_width + 1 + title.chars().count() + epic_marker_width;
     let mut spans = vec![Span::styled(format!("{marker} "), style)];
     spans.extend(result_ref_spans(result, ref_width, style));
@@ -242,7 +242,7 @@ fn result_line(
 }
 
 fn result_ref_spans(result: &SearchResultItem, width: usize, style: Style) -> Vec<Span<'static>> {
-    let display_ref = truncate_chars(&result.display_ref, width);
+    let display_ref = truncate_width(&result.display_ref, width);
     let bg = style.bg.unwrap_or(BG);
     if let Some((project, suffix)) = display_ref.split_once('-') {
         let used_width = project.chars().count() + 1 + suffix.chars().count();
@@ -379,7 +379,7 @@ fn result_meta_line(
 }
 
 fn padded_meta_line(value: &str, style: Style, width: usize) -> Line<'static> {
-    let value = truncate_chars(value, width);
+    let value = truncate_width(value, width);
     let padding = width.saturating_sub(value.chars().count());
     Line::from(vec![
         Span::styled(value, style),
@@ -399,7 +399,7 @@ fn truncate_spans_to_width(spans: &mut Vec<Span<'static>>, width: usize) {
         let content_width = spans[index].content.chars().count();
         if used + content_width > width {
             let remaining = width.saturating_sub(used);
-            spans[index].content = truncate_chars(&spans[index].content, remaining).into();
+            spans[index].content = truncate_width(&spans[index].content, remaining).into();
             spans.truncate(index + 1);
             return;
         }

--- a/src/tui/ui/recent_actions.rs
+++ b/src/tui/ui/recent_actions.rs
@@ -7,7 +7,7 @@ use ratatui::widgets::{
 };
 
 use super::timestamps::local_timestamp_display;
-use super::truncate::truncate_chars;
+use super::truncate::truncate_width;
 use crate::change_log::op_type;
 use crate::query::RecentActionItem;
 use crate::queue::{now_seconds, unix_seconds};
@@ -203,7 +203,7 @@ fn render_action_row(
         row_style.bg.unwrap_or(BG),
     );
     let sync_marker = if action.synced { "✓" } else { "•" };
-    let summary = truncate_chars(&action.summary, cells[4].width.saturating_sub(1) as usize);
+    let summary = truncate_width(&action.summary, cells[4].width.saturating_sub(1) as usize);
     let values = [
         Line::from(vec![Span::styled(
             format!(" {when}"),
@@ -219,7 +219,7 @@ fn render_action_row(
             ),
             Span::styled(" ", row_style),
             Span::styled(
-                truncate_chars(&action.verb, cells[1].width.saturating_sub(4) as usize),
+                truncate_width(&action.verb, cells[1].width.saturating_sub(4) as usize),
                 row_style.fg(FG),
             ),
         ]),
@@ -271,7 +271,7 @@ fn action_project_cell(
     let Some(project_key) = project_key else {
         return Line::from("");
     };
-    let project = truncate_chars(project_key, max_width.saturating_sub(1));
+    let project = truncate_width(project_key, max_width.saturating_sub(1));
     Line::from(vec![
         Span::styled(project, Style::new().fg(FG_MUTED).bg(bg)),
         Span::styled(" ", Style::new().bg(bg)),

--- a/src/tui/ui/sidebar.rs
+++ b/src/tui/ui/sidebar.rs
@@ -5,7 +5,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, BorderType, Borders, Clear, List, ListItem, ListState};
 use unicode_width::UnicodeWidthStr;
 
-use super::truncate::truncate_chars;
+use super::truncate::truncate_width;
 use crate::choices::TaskPriority;
 use crate::tui::app::Focus;
 use crate::tui::list_surface::ListSurface;
@@ -348,7 +348,7 @@ fn sidebar_entry_line(
     let count = entry.count.to_string();
     let reserved_width = marker_cell.width() + count.width() + 1;
     let label_width = width.saturating_sub(reserved_width);
-    let label = truncate_chars(label, label_width);
+    let label = truncate_width(label, label_width);
     let used_width = marker_cell.width() + label.width() + count.width();
     let spacer_width = width.saturating_sub(used_width).max(1);
     let count_style = if active {

--- a/src/tui/ui/task_list.rs
+++ b/src/tui/ui/task_list.rs
@@ -13,7 +13,7 @@ pub(crate) use self::hit_test::TaskListHit;
 use super::input::clipped_input_line;
 use super::task_display::{description_or_placeholder, labels_display};
 use super::timestamps::local_timestamp_display;
-use super::truncate::truncate_chars;
+use super::truncate::truncate_width;
 use crate::query::{TaskListItem, TaskSort};
 use crate::queue::{now_seconds, unix_seconds};
 use crate::tui::app::Focus;
@@ -1045,7 +1045,7 @@ fn build_epic_child_row_cells(
 ) -> Vec<Line<'static>> {
     let branch = if last { "└─" } else { "├─" };
     let ref_prefix = format!("{}{branch} ", if marked { "●" } else { " " });
-    let display_ref = truncate_chars(
+    let display_ref = truncate_width(
         &item.display_ref,
         column_widths[0].saturating_sub(ref_prefix.chars().count() + 1),
     );
@@ -1225,7 +1225,7 @@ fn compact_age(age_seconds: i64) -> String {
 }
 
 fn project_cell(item: &TaskListItem, max_width: usize) -> Line<'static> {
-    let project = truncate_chars(&item.task.project_key, max_width.saturating_sub(1));
+    let project = truncate_width(&item.task.project_key, max_width.saturating_sub(1));
     Line::from(vec![
         Span::styled(
             project,
@@ -1299,7 +1299,7 @@ fn availability_preview_line(
     )?;
     let countdown = relative.strip_prefix("available ").unwrap_or(&relative);
     let fixed_width = "available ".len() + countdown.len() + " · ".len();
-    let local = truncate_chars(&local, width.saturating_sub(fixed_width));
+    let local = truncate_width(&local, width.saturating_sub(fixed_width));
 
     Some(Line::from(vec![
         Span::styled("available ", Style::new().fg(FG_DIM)),
@@ -1317,7 +1317,7 @@ fn due_preview_line(item: &TaskListItem, now_seconds: i64, width: usize) -> Opti
     let [relative, date] = crate::tui::time::due_summary_lines(due_on, now_seconds)?;
     let relative = relative.strip_prefix("due ").unwrap_or(&relative);
     let fixed_width = "due ".len() + relative.len() + " · ".len();
-    let date = truncate_chars(&date, width.saturating_sub(fixed_width));
+    let date = truncate_width(&date, width.saturating_sub(fixed_width));
     let color = if !item.task.status.is_open() {
         FG_MUTED
     } else {

--- a/src/tui/ui/truncate.rs
+++ b/src/tui/ui/truncate.rs
@@ -23,45 +23,9 @@ pub(super) fn truncate_width(value: &str, max_width: usize) -> String {
     truncated
 }
 
-pub(super) fn truncate_chars(value: &str, max_chars: usize) -> String {
-    if value.chars().count() <= max_chars {
-        return value.to_string();
-    }
-    if max_chars == 0 {
-        return String::new();
-    }
-    if max_chars == 1 {
-        return "…".to_string();
-    }
-    let mut truncated = value.chars().take(max_chars - 1).collect::<String>();
-    truncated.push('…');
-    truncated
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn truncate_chars_preserves_short_values() {
-        assert_eq!(truncate_chars("abc", 5), "abc");
-    }
-
-    #[test]
-    fn truncate_chars_returns_empty_for_zero_width() {
-        assert_eq!(truncate_chars("abc", 0), "");
-    }
-
-    #[test]
-    fn truncate_chars_uses_single_ellipsis_for_width_one() {
-        assert_eq!(truncate_chars("abc", 1), "…");
-    }
-
-    #[test]
-    fn truncate_chars_uses_character_count() {
-        assert_eq!(truncate_chars("abcdef", 4), "abc…");
-        assert_eq!(truncate_chars("éclair", 4), "écl…");
-    }
 
     #[test]
     fn truncate_width_uses_display_width() {


### PR DESCRIPTION
Typing Korean in the TUI misplaces the input method composition and, once the
value grows, pushes the caret off screen. Both come from the same root cause:
text layout is measured in characters, and the terminal cursor is never told
where the caret is.

### Terminal cursor never follows the caret

The TUI paints its own cursor cell and never calls `set_cursor_position`, so
Ratatui hides the terminal cursor and leaves it wherever the buffer diff
stopped writing. Input method editors draw in-progress composition at the
terminal cursor, so Korean, Japanese, and Chinese preedit text lands at an
unrelated cell — in the screenshot, at the far right of the row where a
placeholder had just been erased.

The painted caret is now located in the rendered buffer by its cursor style,
and the hidden terminal cursor is moved there after every draw. Nothing about
the rendered frame changes; the painted cursor is still the visible caret.

### Character counts where the terminal counts cells

`input_cursor_spans` budgeted its scroll window in characters, the wrapped
editors split lines with a character-count splitter, and `truncate_chars`
shortened values that every caller sizes from a layout width. A wide character
takes two cells, so CJK values render twice as wide as the field: titles
overflow their dialog, the caret disappears past half the width, and sidebar
labels, task rows, search results, and column cards spill out of their
columns.

Each of those now measures cells, dropping characters whole so a wide
character never renders as half a cell.

### Testing

`cargo fmt`, `cargo clippy --all-targets`, and the test suite are clean, plus
new coverage for cell budgeting, wide-character line splitting, and the
reported caret position matching the painted cell. Verified by hand on macOS
with a Korean input method: composition now appears at the caret, and long
Korean titles scroll inside the dialog.

Two `detail_mode` tests (`detail_back_returns_from_epic_child_to_parent_detail`
and `clicking_detail_markdown_link_opens_browser`) fail for me on an unmodified
`main` as well, so they look unrelated to this change.
