### PR TITLE
Support day, month, and year recurrence intervals

### DIFF
--- a/crates/aven-core/migrations/20260811183348_support_interval_and_yearly_recurrence.sql
+++ b/crates/aven-core/migrations/20260811183348_support_interval_and_yearly_recurrence.sql
@@ -1,0 +1,69 @@
+CREATE TABLE recurrence_series_new (
+    workspace_id TEXT NOT NULL,
+    id TEXT NOT NULL,
+    title TEXT NOT NULL,
+    description TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    priority TEXT NOT NULL,
+    initial_status TEXT NOT NULL,
+    frequency TEXT NOT NULL,
+    interval INTEGER NOT NULL,
+    weekdays TEXT NOT NULL,
+    timezone TEXT NOT NULL,
+    start_on TEXT NOT NULL,
+    available_local_time TEXT NOT NULL DEFAULT '',
+    due_policy TEXT NOT NULL,
+    state TEXT NOT NULL,
+    stopped_at TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    deleted INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (workspace_id, id),
+    CHECK (priority IN ('none', 'low', 'medium', 'high', 'urgent')),
+    CHECK (initial_status IN ('inbox', 'backlog', 'todo', 'active')),
+    CHECK (frequency IN ('daily', 'weekly', 'monthly', 'yearly')),
+    CHECK (interval > 0),
+    CHECK (
+        (frequency = 'weekly' AND weekdays != '')
+        OR (frequency IN ('daily', 'monthly', 'yearly') AND weekdays = '')
+    ),
+    CHECK (due_policy IN ('same_day', 'none')),
+    CHECK (state IN ('active', 'paused', 'stopped')),
+    CHECK (
+        (state = 'stopped' AND stopped_at != '')
+        OR (state != 'stopped' AND stopped_at = '')
+    ),
+    CHECK (deleted IN (0, 1))
+);
+
+INSERT INTO recurrence_series_new (
+    workspace_id, id, title, description, project_id, priority, initial_status,
+    frequency, interval, weekdays, timezone, start_on, available_local_time,
+    due_policy, state, stopped_at, created_at, updated_at, deleted
+)
+SELECT
+    workspace_id, id, title, description, project_id, priority, initial_status,
+    frequency, interval, weekdays, timezone, start_on, available_local_time,
+    due_policy, state, stopped_at, created_at, updated_at, deleted
+FROM recurrence_series;
+
+DROP TABLE recurrence_series;
+ALTER TABLE recurrence_series_new RENAME TO recurrence_series;
+
+CREATE TRIGGER recurrence_series_schedule_immutable
+BEFORE UPDATE OF frequency, interval, weekdays, timezone, start_on
+ON recurrence_series
+WHEN NEW.frequency != OLD.frequency
+    OR NEW.interval != OLD.interval
+    OR NEW.weekdays != OLD.weekdays
+    OR NEW.timezone != OLD.timezone
+    OR NEW.start_on != OLD.start_on
+BEGIN
+    SELECT RAISE(ABORT, 'recurrence schedule is immutable');
+END;
+
+CREATE INDEX idx_recurrence_series_lifecycle
+ON recurrence_series(workspace_id, state, deleted);
+
+CREATE INDEX idx_recurrence_series_project
+ON recurrence_series(workspace_id, project_id, deleted);

--- a/crates/aven-core/src/query/recurrence.rs
+++ b/crates/aven-core/src/query/recurrence.rs
@@ -948,8 +948,12 @@ async fn load_task_display_refs(
 
 fn rule_label(frequency: String, interval: u32, weekdays: String) -> String {
     match (frequency.as_str(), interval, weekdays.as_str()) {
-        ("daily", _, _) => "daily".to_string(),
-        ("monthly", _, _) => "monthly".to_string(),
+        ("daily", 1, _) => "daily".to_string(),
+        ("daily", interval, _) => format!("every {interval} days"),
+        ("monthly", 1, _) => "monthly".to_string(),
+        ("monthly", interval, _) => format!("every {interval} months"),
+        ("yearly", 1, _) => "yearly".to_string(),
+        ("yearly", interval, _) => format!("every {interval} years"),
         ("weekly", 1, "mon,tue,wed,thu,fri") => "weekdays".to_string(),
         ("weekly", 1, days) => format!("weekly on {days}"),
         ("weekly", interval, days) => format!("every {interval} weeks on {days}"),

--- a/crates/aven-core/src/recurrence/rule.rs
+++ b/crates/aven-core/src/recurrence/rule.rs
@@ -10,6 +10,7 @@ pub enum RecurrenceFrequency {
     Daily,
     Weekly,
     Monthly,
+    Yearly,
 }
 
 impl RecurrenceFrequency {
@@ -18,6 +19,7 @@ impl RecurrenceFrequency {
             Self::Daily => "daily",
             Self::Weekly => "weekly",
             Self::Monthly => "monthly",
+            Self::Yearly => "yearly",
         }
     }
 
@@ -26,6 +28,7 @@ impl RecurrenceFrequency {
             "daily" => Ok(Self::Daily),
             "weekly" => Ok(Self::Weekly),
             "monthly" => Ok(Self::Monthly),
+            "yearly" => Ok(Self::Yearly),
             _ => Err(InvalidRecurrenceFrequency(value.to_string())),
         }
     }
@@ -153,24 +156,19 @@ impl RecurrenceRule {
         interval: u32,
         weekdays: WeekdaySet,
     ) -> Result<Self, InvalidRecurrenceRule> {
+        if interval == 0 {
+            return Err(InvalidRecurrenceRule::ZeroInterval);
+        }
         match frequency {
-            RecurrenceFrequency::Daily if interval != 1 => {
-                return Err(InvalidRecurrenceRule::DailyInterval);
-            }
-            RecurrenceFrequency::Daily if !weekdays.is_empty() => {
-                return Err(InvalidRecurrenceRule::DailyWeekdays);
-            }
-            RecurrenceFrequency::Weekly if interval == 0 => {
-                return Err(InvalidRecurrenceRule::ZeroInterval);
-            }
             RecurrenceFrequency::Weekly if weekdays.is_empty() => {
                 return Err(InvalidRecurrenceRule::EmptyWeekdays);
             }
-            RecurrenceFrequency::Monthly if interval != 1 => {
-                return Err(InvalidRecurrenceRule::MonthlyInterval);
-            }
-            RecurrenceFrequency::Monthly if !weekdays.is_empty() => {
-                return Err(InvalidRecurrenceRule::MonthlyWeekdays);
+            RecurrenceFrequency::Daily
+            | RecurrenceFrequency::Monthly
+            | RecurrenceFrequency::Yearly
+                if !weekdays.is_empty() =>
+            {
+                return Err(InvalidRecurrenceRule::UnexpectedWeekdays);
             }
             _ => {}
         }
@@ -189,6 +187,10 @@ impl RecurrenceRule {
         }
     }
 
+    pub fn every_n_days(interval: u32) -> Result<Self, InvalidRecurrenceRule> {
+        Self::new(RecurrenceFrequency::Daily, interval, WeekdaySet::default())
+    }
+
     pub fn weekdays() -> Self {
         Self {
             frequency: RecurrenceFrequency::Weekly,
@@ -203,6 +205,26 @@ impl RecurrenceRule {
             interval: 1,
             weekdays: WeekdaySet::default(),
         }
+    }
+
+    pub fn every_n_months(interval: u32) -> Result<Self, InvalidRecurrenceRule> {
+        Self::new(
+            RecurrenceFrequency::Monthly,
+            interval,
+            WeekdaySet::default(),
+        )
+    }
+
+    pub fn yearly() -> Self {
+        Self {
+            frequency: RecurrenceFrequency::Yearly,
+            interval: 1,
+            weekdays: WeekdaySet::default(),
+        }
+    }
+
+    pub fn every_n_years(interval: u32) -> Result<Self, InvalidRecurrenceRule> {
+        Self::new(RecurrenceFrequency::Yearly, interval, WeekdaySet::default())
     }
 
     pub fn weekly(weekday: Weekday) -> Self {
@@ -243,7 +265,9 @@ impl RecurrenceRule {
             return false;
         }
         match self.frequency {
-            RecurrenceFrequency::Daily => true,
+            RecurrenceFrequency::Daily => {
+                date.signed_duration_since(start_on).num_days() % i64::from(self.interval) == 0
+            }
             RecurrenceFrequency::Weekly => {
                 let days_from_anchor = i64::from(start_on.weekday().num_days_from_monday())
                     + date.signed_duration_since(start_on).num_days();
@@ -252,6 +276,12 @@ impl RecurrenceRule {
             }
             RecurrenceFrequency::Monthly => {
                 date.day() == start_on.day().min(last_day_of_month(date))
+                    && months_between(start_on, date) % i64::from(self.interval) == 0
+            }
+            RecurrenceFrequency::Yearly => {
+                date.month() == start_on.month()
+                    && date.day() == start_on.day().min(last_day_of_month(date))
+                    && i64::from(date.year() - start_on.year()) % i64::from(self.interval) == 0
             }
         }
     }
@@ -278,26 +308,25 @@ impl<'de> Deserialize<'de> for RecurrenceRule {
 pub enum InvalidRecurrenceRule {
     ZeroInterval,
     EmptyWeekdays,
-    DailyInterval,
-    DailyWeekdays,
-    MonthlyInterval,
-    MonthlyWeekdays,
+    UnexpectedWeekdays,
 }
 
 impl fmt::Display for InvalidRecurrenceRule {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str(match self {
-            Self::ZeroInterval => "weekly recurrence interval must be greater than zero",
+            Self::ZeroInterval => "recurrence interval must be greater than zero",
             Self::EmptyWeekdays => "weekly recurrence must contain at least one weekday",
-            Self::DailyInterval => "daily recurrence interval must be one",
-            Self::DailyWeekdays => "daily recurrence cannot contain a weekday set",
-            Self::MonthlyInterval => "monthly recurrence interval must be one",
-            Self::MonthlyWeekdays => "monthly recurrence cannot contain a weekday set",
+            Self::UnexpectedWeekdays => "only weekly recurrence can contain a weekday set",
         })
     }
 }
 
 impl std::error::Error for InvalidRecurrenceRule {}
+
+fn months_between(start: chrono::NaiveDate, date: chrono::NaiveDate) -> i64 {
+    (i64::from(date.year()) * 12 + i64::from(date.month0()))
+        - (i64::from(start.year()) * 12 + i64::from(start.month0()))
+}
 
 fn last_day_of_month(date: chrono::NaiveDate) -> u32 {
     (28..=31)

--- a/crates/aven-core/src/recurrence/tests.rs
+++ b/crates/aven-core/src/recurrence/tests.rs
@@ -54,8 +54,28 @@ fn rules_reject_values_outside_the_fixed_schedule_lattice() {
     );
     assert!(RecurrenceRule::weekly_on([]).is_err());
     assert!(RecurrenceRule::new(RecurrenceFrequency::Weekly, 1, WeekdaySet::default()).is_err());
-    assert!(RecurrenceRule::new(RecurrenceFrequency::Daily, 2, WeekdaySet::default(),).is_err());
-    assert!(RecurrenceRule::new(RecurrenceFrequency::Monthly, 2, WeekdaySet::default()).is_err());
+    assert!(RecurrenceRule::new(RecurrenceFrequency::Daily, 0, WeekdaySet::default()).is_err());
+    assert!(RecurrenceRule::new(RecurrenceFrequency::Monthly, 0, WeekdaySet::default()).is_err());
+    assert!(RecurrenceRule::new(RecurrenceFrequency::Yearly, 0, WeekdaySet::default()).is_err());
+    assert!(RecurrenceRule::new(RecurrenceFrequency::Daily, 2, WeekdaySet::default()).is_ok());
+    assert!(RecurrenceRule::new(RecurrenceFrequency::Monthly, 2, WeekdaySet::default()).is_ok());
+    assert!(RecurrenceRule::new(RecurrenceFrequency::Yearly, 2, WeekdaySet::default()).is_ok());
+    assert!(
+        RecurrenceRule::new(
+            RecurrenceFrequency::Daily,
+            1,
+            WeekdaySet::from_weekdays([Weekday::Mon]),
+        )
+        .is_err()
+    );
+    assert!(
+        RecurrenceRule::new(
+            RecurrenceFrequency::Yearly,
+            1,
+            WeekdaySet::from_weekdays([Weekday::Mon]),
+        )
+        .is_err()
+    );
     assert!(
         RecurrenceRule::new(
             RecurrenceFrequency::Monthly,
@@ -113,6 +133,84 @@ fn daily_and_weekday_iteration_crosses_leap_dates() {
             date(2026, 7, 21),
             date(2026, 7, 22),
         ]
+    );
+}
+
+#[test]
+fn day_intervals_anchor_on_the_start_date() {
+    let every_third = schedule(
+        RecurrenceRule::every_n_days(3).unwrap(),
+        "UTC",
+        date(2026, 8, 10),
+        None,
+        RecurrenceDuePolicy::SameDay,
+    );
+    assert_eq!(
+        every_third
+            .slots_on_or_after(date(2026, 8, 10))
+            .take(3)
+            .collect::<Vec<_>>(),
+        vec![date(2026, 8, 10), date(2026, 8, 13), date(2026, 8, 16)]
+    );
+    assert_eq!(
+        every_third.slots_on_or_after(date(2026, 8, 11)).next(),
+        Some(date(2026, 8, 13))
+    );
+}
+
+#[test]
+fn month_intervals_anchor_on_the_start_month_and_clamp_days() {
+    let quarterly = schedule(
+        RecurrenceRule::every_n_months(3).unwrap(),
+        "UTC",
+        date(2026, 1, 31),
+        None,
+        RecurrenceDuePolicy::SameDay,
+    );
+    assert_eq!(
+        quarterly
+            .slots_on_or_after(quarterly.start_on)
+            .take(4)
+            .collect::<Vec<_>>(),
+        vec![
+            date(2026, 1, 31),
+            date(2026, 4, 30),
+            date(2026, 7, 31),
+            date(2026, 10, 31),
+        ]
+    );
+}
+
+#[test]
+fn yearly_iteration_clamps_leap_anchors_without_drifting() {
+    let yearly = schedule(
+        RecurrenceRule::yearly(),
+        "UTC",
+        date(2028, 2, 29),
+        None,
+        RecurrenceDuePolicy::SameDay,
+    );
+    assert_eq!(
+        yearly
+            .slots_on_or_after(yearly.start_on)
+            .take(3)
+            .collect::<Vec<_>>(),
+        vec![date(2028, 2, 29), date(2029, 2, 28), date(2030, 2, 28)]
+    );
+
+    let biennial = schedule(
+        RecurrenceRule::every_n_years(2).unwrap(),
+        "UTC",
+        date(2026, 8, 11),
+        None,
+        RecurrenceDuePolicy::SameDay,
+    );
+    assert_eq!(
+        biennial
+            .slots_on_or_after(biennial.start_on)
+            .take(3)
+            .collect::<Vec<_>>(),
+        vec![date(2026, 8, 11), date(2028, 8, 11), date(2030, 8, 11)]
     );
 }
 

--- a/crates/aven-core/src/sync/wire.rs
+++ b/crates/aven-core/src/sync/wire.rs
@@ -19,7 +19,7 @@ use crate::recurrence::{
 };
 use crate::task_fields::TaskField;
 
-pub const SYNC_PROTOCOL_VERSION: u32 = 13;
+pub const SYNC_PROTOCOL_VERSION: u32 = 14;
 const MAX_CHANGE_PAYLOAD_BYTES: usize = 64 * 1024;
 pub fn sync_server_url_is_valid(server: &str) -> bool {
     let Ok(url) = url::Url::parse(server) else {
@@ -1868,7 +1868,7 @@ mod tests {
         ))
         .unwrap();
         assert_eq!(serde_json::to_value(delete).unwrap(), delete_value);
-        assert_eq!(SYNC_PROTOCOL_VERSION, 13);
+        assert_eq!(SYNC_PROTOCOL_VERSION, 14);
     }
 
     #[test]

--- a/crates/aven-uniffi/src/lib.rs
+++ b/crates/aven-uniffi/src/lib.rs
@@ -161,6 +161,7 @@ pub enum RecurrenceFrequency {
     Daily,
     Weekly,
     Monthly,
+    Yearly,
 }
 
 impl From<RecurrenceFrequency> for core_api::RecurrenceFrequency {
@@ -169,6 +170,7 @@ impl From<RecurrenceFrequency> for core_api::RecurrenceFrequency {
             RecurrenceFrequency::Daily => Self::Daily,
             RecurrenceFrequency::Weekly => Self::Weekly,
             RecurrenceFrequency::Monthly => Self::Monthly,
+            RecurrenceFrequency::Yearly => Self::Yearly,
         }
     }
 }
@@ -179,6 +181,7 @@ impl From<core_api::RecurrenceFrequency> for RecurrenceFrequency {
             core_api::RecurrenceFrequency::Daily => Self::Daily,
             core_api::RecurrenceFrequency::Weekly => Self::Weekly,
             core_api::RecurrenceFrequency::Monthly => Self::Monthly,
+            core_api::RecurrenceFrequency::Yearly => Self::Yearly,
         }
     }
 }

--- a/docs/src/content/docs/command-reference.md
+++ b/docs/src/content/docs/command-reference.md
@@ -113,19 +113,25 @@ aven list --overdue
 | `weekly` | Every week on the start date's weekday. |
 | `fortnightly` | Every two weeks on the start date's weekday. |
 | `monthly` | The start date's day number every month. |
+| `yearly` | The start date's month and day every year. |
 | `weekly on mon,wed,fri` | The selected weekdays every week. |
+| `every N days` | Every N days from the start date. |
 | `every N weeks` | Every N weeks on the start date's weekday. |
 | `every N weeks on mon,thu` | The selected weekdays every N weeks. |
+| `every N months` | The start date's day number every N months. |
+| `every N years` | The start date's month and day every N years. |
 
 Explicit weekdays use the canonical abbreviations `mon`, `tue`, `wed`, `thu`,
 `fri`, `sat`, and `sun`, listed in Monday-to-Sunday order. `N` must be a
 positive whole number. Weeks begin on Monday.
 
 Monthly schedules use the final day of shorter months. A schedule starting on
-January 31 runs on February 28 or 29, then March 31.
+January 31 runs on February 28 or 29, then March 31. Yearly schedules starting
+on February 29 use February 28 outside leap years.
 
 The TUI schedule field also accepts friendly forms such as `every day`, `every
-Friday`, `Fridays`, `every month`, and `every 3 weeks on Monday and Thursday`.
+Friday`, `Fridays`, `every month`, `every year`, `annually`, `every 3 days`,
+and `every 3 weeks on Monday and Thursday`.
 See [Recurring tasks](/recurring-tasks/) for creation workflows and schedule
 behavior.
 

--- a/docs/src/content/docs/recurring-tasks.md
+++ b/docs/src/content/docs/recurring-tasks.md
@@ -49,16 +49,24 @@ and start date. The schedule uses your device's time zone.
 | Weekly | `every Friday` |
 | Every two weeks | `fortnightly` |
 | Selected weekdays | `every Monday and Thursday` |
+| Every N days | `every 3 days` |
 | Every N weeks | `every 3 weeks` |
 | Selected days every N weeks | `every 3 weeks on Monday and Thursday` |
 | Monthly | `every month` |
+| Every N months | `every 2 months` |
+| Yearly | `yearly` or `annually` |
+| Every N years | `every 2 years` |
 
 Weeks begin on Monday. A weekly or fortnightly schedule without an explicit
 weekday uses the start date's weekday.
 
 Monthly schedules keep their original day number. When a month is shorter, Aven
 uses its last day without changing the schedule. A task that starts on January
-31 returns on February 28 or 29, then March 31.
+31 returns on February 28 or 29, then March 31. Yearly schedules keep their
+original month and day; a task that starts on February 29 returns on February
+28 outside leap years.
+
+Day-based schedules such as `every 3 days` count from the start date.
 
 ## Choose when tasks become available and due
 

--- a/src/commands/recurrence.rs
+++ b/src/commands/recurrence.rs
@@ -118,6 +118,7 @@ fn parse_rule(value: &str, start_on: NaiveDate) -> Result<RecurrenceRule> {
             return RecurrenceRule::every_n_weeks_on(2, [start_on.weekday()]).map_err(Into::into);
         }
         "monthly" => return Ok(RecurrenceRule::monthly()),
+        "yearly" => return Ok(RecurrenceRule::yearly()),
         _ => {}
     }
     if let Some(days) = value.strip_prefix("weekly on ") {
@@ -125,26 +126,36 @@ fn parse_rule(value: &str, start_on: NaiveDate) -> Result<RecurrenceRule> {
         return RecurrenceRule::weekly_on(weekdays.iter()).map_err(Into::into);
     }
     let words = value.split(' ').collect::<Vec<_>>();
+    if let ["every", interval, "days"] = words.as_slice() {
+        let interval = parse_rule_interval(interval)?;
+        return RecurrenceRule::every_n_days(interval).map_err(Into::into);
+    }
     if let ["every", interval, "weeks"] = words.as_slice() {
-        let interval = parse_week_interval(interval)?;
+        let interval = parse_rule_interval(interval)?;
         return RecurrenceRule::every_n_weeks_on(interval, [start_on.weekday()])
             .map_err(Into::into);
     }
+    if let ["every", interval, "months"] = words.as_slice() {
+        let interval = parse_rule_interval(interval)?;
+        return RecurrenceRule::every_n_months(interval).map_err(Into::into);
+    }
+    if let ["every", interval, "years"] = words.as_slice() {
+        let interval = parse_rule_interval(interval)?;
+        return RecurrenceRule::every_n_years(interval).map_err(Into::into);
+    }
     if let ["every", interval, "weeks", "on", days] = words.as_slice() {
-        let interval = parse_week_interval(interval)?;
+        let interval = parse_rule_interval(interval)?;
         let weekdays = days.parse::<WeekdaySet>().map_err(anyhow::Error::msg)?;
         return RecurrenceRule::every_n_weeks_on(interval, weekdays.iter()).map_err(Into::into);
     }
     bail!(
-        "error invalid-repeat-rule value={value:?} hint=\"use daily, weekdays, weekly, fortnightly, monthly, weekly on mon,wed,fri, every N weeks, or every N weeks on mon,thu\""
+        "error invalid-repeat-rule value={value:?} hint=\"use daily, weekdays, weekly, fortnightly, monthly, yearly, weekly on mon,wed,fri, every N days, every N weeks, every N months, every N years, or every N weeks on mon,thu\""
     )
 }
 
-fn parse_week_interval(value: &str) -> Result<u32> {
+fn parse_rule_interval(value: &str) -> Result<u32> {
     value.parse::<u32>().with_context(|| {
-        format!(
-            "error invalid-repeat-interval value={value:?} hint=\"use a whole number of weeks\""
-        )
+        format!("error invalid-repeat-interval value={value:?} hint=\"use a whole number\"")
     })
 }
 
@@ -696,8 +707,12 @@ mod tests {
             "weekly",
             "fortnightly",
             "monthly",
+            "yearly",
             "weekly on mon,wed,fri",
+            "every 3 days",
             "every 2 weeks",
+            "every 6 months",
+            "every 2 years",
             "every 2 weeks on tue",
             "every 3 weeks on mon,thu",
         ] {
@@ -711,9 +726,22 @@ mod tests {
             parse_rule("every 3 weeks", monday).unwrap(),
             RecurrenceRule::every_n_weeks_on(3, [chrono::Weekday::Mon]).unwrap()
         );
+        assert_eq!(
+            parse_rule("every 3 days", monday).unwrap(),
+            RecurrenceRule::every_n_days(3).unwrap()
+        );
+        assert_eq!(
+            parse_rule("yearly", monday).unwrap(),
+            RecurrenceRule::yearly()
+        );
+        assert_eq!(
+            parse_rule("every 6 months", monday).unwrap(),
+            RecurrenceRule::every_n_months(6).unwrap()
+        );
         for rule in [
-            "every 3 days",
+            "every 0 days",
             "every 0 weeks",
+            "every 0 months",
             "weekly on monday",
             "weekly on fri,mon",
             "every two weeks on tue",

--- a/src/recurrence_input.rs
+++ b/src/recurrence_input.rs
@@ -18,6 +18,9 @@ pub(crate) fn canonical_rule_input(input: &str) -> Result<Option<String>> {
     if matches!(normalized.as_str(), "monthly" | "every month") {
         return Ok(Some("monthly".to_string()));
     }
+    if matches!(normalized.as_str(), "yearly" | "annually" | "every year") {
+        return Ok(Some("yearly".to_string()));
+    }
     if normalized == "fortnightly" {
         return Ok(Some("fortnightly".to_string()));
     }
@@ -32,8 +35,8 @@ pub(crate) fn canonical_rule_input(input: &str) -> Result<Option<String>> {
         if let Some(day) = parse_weekday(days) {
             return Ok(Some(format!("weekly on {}", weekday_short(day))));
         }
-        if let Some(interval) = parse_week_count(days)? {
-            return Ok(Some(format!("every {interval} weeks")));
+        if let Some((interval, unit)) = parse_interval_count(days)? {
+            return Ok(Some(format!("every {interval} {unit}")));
         }
         if let Some((interval, days)) = parse_week_interval(days)? {
             return Ok(Some(format!(
@@ -47,11 +50,16 @@ pub(crate) fn canonical_rule_input(input: &str) -> Result<Option<String>> {
     bail!(rule_guidance())
 }
 
-fn parse_week_count(value: &str) -> Result<Option<u32>> {
-    let Some(interval) = value.strip_suffix(" weeks") else {
-        return Ok(None);
-    };
-    parse_positive_interval(interval).map(Some)
+fn parse_interval_count(value: &str) -> Result<Option<(u32, &'static str)>> {
+    for unit in ["days", "weeks", "months", "years"] {
+        if let Some(interval) = value
+            .strip_suffix(unit)
+            .and_then(|rest| rest.strip_suffix(' '))
+        {
+            return Ok(Some((parse_positive_interval(interval)?, unit)));
+        }
+    }
+    Ok(None)
 }
 
 fn parse_week_interval(value: &str) -> Result<Option<(u32, &str)>> {
@@ -130,8 +138,12 @@ fn weekday_name(weekday: Weekday) -> &'static str {
 
 pub(crate) fn natural_rule_label(rule: RecurrenceRule) -> String {
     match rule.frequency() {
-        RecurrenceFrequency::Daily => "Every day".to_string(),
-        RecurrenceFrequency::Monthly => "Every month".to_string(),
+        RecurrenceFrequency::Daily if rule.interval() == 1 => "Every day".to_string(),
+        RecurrenceFrequency::Daily => format!("Every {} days", rule.interval()),
+        RecurrenceFrequency::Monthly if rule.interval() == 1 => "Every month".to_string(),
+        RecurrenceFrequency::Monthly => format!("Every {} months", rule.interval()),
+        RecurrenceFrequency::Yearly if rule.interval() == 1 => "Every year".to_string(),
+        RecurrenceFrequency::Yearly => format!("Every {} years", rule.interval()),
         RecurrenceFrequency::Weekly if rule == RecurrenceRule::weekdays() => {
             "Every weekday".to_string()
         }
@@ -160,7 +172,7 @@ pub(crate) fn natural_rule_label(rule: RecurrenceRule) -> String {
 }
 
 pub(crate) const fn rule_guidance() -> &'static str {
-    "Try daily, weekdays, monthly, fortnightly, every Friday, every 3 weeks, or every 4 weeks on Monday and Thursday"
+    "Try daily, weekdays, monthly, yearly, fortnightly, every Friday, every 3 days, every 3 weeks, every 2 months, or every 4 weeks on Monday and Thursday"
 }
 
 #[cfg(test)]
@@ -174,13 +186,19 @@ mod tests {
             ("every day", "daily"),
             ("monthly", "monthly"),
             ("every month", "monthly"),
+            ("yearly", "yearly"),
+            ("annually", "yearly"),
+            ("every year", "yearly"),
             ("fortnightly", "fortnightly"),
             ("weekdays", "weekdays"),
             ("every weekday", "weekdays"),
             ("every Friday", "weekly on fri"),
             ("Fridays", "weekly on fri"),
             ("every Monday and Thursday", "weekly on mon,thu"),
+            ("every 3 days", "every 3 days"),
             ("every 3 weeks", "every 3 weeks"),
+            ("every 2 months", "every 2 months"),
+            ("every 2 years", "every 2 years"),
             (
                 "every 4 weeks on Monday and Thursday",
                 "every 4 weeks on mon,thu",
@@ -203,7 +221,16 @@ mod tests {
     #[test]
     fn formats_rules_in_natural_language() {
         assert_eq!(natural_rule_label(RecurrenceRule::daily()), "Every day");
+        assert_eq!(
+            natural_rule_label(RecurrenceRule::every_n_days(3).unwrap()),
+            "Every 3 days"
+        );
         assert_eq!(natural_rule_label(RecurrenceRule::monthly()), "Every month");
+        assert_eq!(
+            natural_rule_label(RecurrenceRule::every_n_months(6).unwrap()),
+            "Every 6 months"
+        );
+        assert_eq!(natural_rule_label(RecurrenceRule::yearly()), "Every year");
         assert_eq!(
             natural_rule_label(RecurrenceRule::weekdays()),
             "Every weekday"

--- a/src/task_intake.rs
+++ b/src/task_intake.rs
@@ -193,7 +193,7 @@ Rules:\n\
 - Set due_on only for a one-off deadline or day by which work should be complete. Use date expressions without times.\n\
 - Keep available_at and due_on independent when the input states both.\n\
 - Set repeat only for clear recurrence intent such as daily, every Friday, or every Monday and Thursday. Ambiguous timing remains one-off.\n\
-- Use natural repeat rules such as daily, weekdays, monthly, fortnightly, every Friday, every 3 weeks, or every 4 weeks on Monday and Thursday.\n\
+- Use natural repeat rules such as daily, weekdays, monthly, yearly, fortnightly, every Friday, every 3 days, every 3 weeks, every 2 months, or every 4 weeks on Monday and Thursday.\n\
 - For recurrence, omit available_at and due_on. Set repeat_at only for a stated recurring availability time, repeat_due only for an explicit same-day or no-due policy, time_zone only for an explicit IANA zone, and repeat_start_on only for an explicit YYYY-MM-DD start date.\n\
 - Recurrence defaults are no availability time, same-day due, the local time zone, and today in that zone.\n\
 - Omit optional fields when they do not apply.\n\

--- a/tests/cli_sync.rs
+++ b/tests/cli_sync.rs
@@ -19,7 +19,7 @@ const SYNC_OPPOSITE_DEP_CHANGE_ID: &str = "FFFFFFFFFFFFFFFF";
 const SYNC_CLIENT_ID: &str = "GGGGGGGGGGGGGGGG";
 const MAX_PUSH_BATCH: usize = 256;
 const MAX_PULL_BATCH: usize = 512;
-const SYNC_PROTOCOL_VERSION: u32 = 13;
+const SYNC_PROTOCOL_VERSION: u32 = 14;
 
 fn sync_round_values(output: &str, key: &str) -> Vec<u64> {
     output


### PR DESCRIPTION
Hi! Thanks for building aven — I use it daily and it has been great.

One gap I kept running into is that the recurrence grammar has no day-based intervals and nothing above monthly, so things like "water the plants every 3 days" or "wedding anniversary every year" can only be approximated with rules like `every 52 weeks`. This PR extends the rule grammar to cover those cases.

## What's added

| Rule | Schedule |
| --- | --- |
| `every N days` | Every N days from the start date. |
| `every N months` | The start date's day number every N months. |
| `yearly` | The start date's month and day every year. |
| `every N years` | Same, every N years. |

All new rules anchor on `--repeat-start-on`, consistent with the existing `monthly` behavior:

- Day intervals count from the start date.
- Month intervals keep the start date's day number and clamp to shorter months (a Jan 31 quarterly series runs Apr 30, Jul 31, Oct 31).
- Yearly rules keep the start month and day; a Feb 29 anchor runs on Feb 28 outside leap years and returns to Feb 29 in leap years.
- Existing rules are untouched — `daily`/`monthly` with interval 1 evaluate exactly as before.

The TUI/natural-language input additionally accepts `annually`, `every year`, and friendly forms like `every 3 days`, and the AI intake prompt and docs are updated to match.

## Implementation notes

- **Core:** `RecurrenceFrequency` gains a `Yearly` variant, and the interval-must-be-1 restriction on daily/monthly is lifted. Weekday sets remain weekly-only.
- **Migration:** `recurrence_series` is rebuilt to relax the frequency/interval CHECK constraints, following the same pattern as `20260728183707_support_monthly_recurrence.sql` (data copied over, trigger and indexes recreated).
- **Sync:** `SYNC_PROTOCOL_VERSION` is bumped 13 → 14 so older peers get a clean `sync-protocol-unsupported` error instead of failing mid-apply on a frequency they can't parse — following the precedent of the task-metadata bump (12 → 13). Happy to handle this differently if you'd prefer another compatibility strategy.
- **uniffi:** the mirrored `RecurrenceFrequency` enum gains `Yearly`.

Deliberately **not** included: `monthly on 15` / `monthly on last day` / `monthly on last fri`, since those need new rule fields (ordinal weekdays, explicit month days) and felt like a separate design discussion. Monthly dates stay start-date-anchored.

## Testing

- New unit tests for the schedule math (day intervals, month clamping, Feb 29 yearly anchors), the CLI grammar, and the natural-language parser.
- `cargo test --workspace`, `cargo clippy`, `cargo fmt` all clean on my machine (the only failures are a handful of pre-existing ones that also fail for me on a clean `main` checkout — happy to share details).
- Manual CLI smoke test: created `yearly`, `every 3 days`, `every 3 months` (Jan 31 anchor → Oct 31 slot), and `every 2 years` series against a fresh DB and verified `recur list` labels and slots.

Happy to adjust anything — naming, migration approach, or scope. Thanks for taking a look!
