### PR TITLE
Accept recurrence resolutions before the slot boundary

### DIFF
--- a/crates/aven-core/src/sync/apply/recurrence.rs
+++ b/crates/aven-core/src/sync/apply/recurrence.rs
@@ -9,7 +9,7 @@ use crate::ids::{ProjectId, TaskId, WorkspaceId};
 use crate::recurrence::{
     RecurrenceDuePolicy, RecurrenceFrequency, RecurrenceOutcome, RecurrenceRule,
     RecurrenceSchedule, RecurrenceSeriesId, RecurrenceSeriesState, TimeZoneId, WeekdaySet,
-    derive_occurrence_identity, is_slot, slot_values,
+    derive_occurrence_identity, is_slot,
 };
 use crate::sync::wire::ChangeWire;
 use crate::task_fields::TaskField;
@@ -435,10 +435,6 @@ async fn apply_outcome(conn: &mut SqliteConnection, change: &ChangeWire) -> Resu
     ensure!(
         is_slot(&schedule.rule, schedule.start_on, slot_on),
         "error recurrence-slot-off-lattice slot={slot_on}"
-    );
-    ensure!(
-        resolved_at >= slot_values(&schedule, slot_on)?.boundary_at,
-        "error invalid-sync-change recurrence-resolution-before-slot"
     );
     let task_id = str_payload(&change.payload, "task_id")?.parse::<TaskId>()?;
     let existing = sqlx::query(

--- a/crates/aven-core/src/sync/wire.rs
+++ b/crates/aven-core/src/sync/wire.rs
@@ -921,10 +921,10 @@ fn validate_recurrence_outcome(change: &ChangeWire) -> Result<()> {
     }
     let outcome = RecurrenceOutcome::parse(&required_string_payload("outcome", &change.payload)?)
         .map_err(|err| anyhow::anyhow!("error invalid-sync-change {err}"))?;
-    let resolved_at = required_timestamp_payload("resolved_at", &change.payload)?;
-    if resolved_at < crate::recurrence::slot_values(&schedule, slot_on)?.boundary_at {
-        bail!("error invalid-sync-change recurrence-resolution-before-slot");
-    }
+    // Clients may resolve the projected occurrence before its slot begins
+    // (e.g. canceling the final occurrence of a stopped series), so
+    // resolved_at is validated for format only, not ordered against the slot.
+    required_timestamp_payload("resolved_at", &change.payload)?;
     let conflict_resolution = change
         .payload
         .get("conflict_resolution")

--- a/tests/cli_sync.rs
+++ b/tests/cli_sync.rs
@@ -3835,6 +3835,61 @@ fn recurrence_complete_skip_creates_series_conflict_without_blocking_projection(
 }
 
 #[test]
+fn recurrence_resolution_before_slot_syncs_and_applies() {
+    let env = TestEnv::new();
+    let server = TestServer::start(&env);
+    let a = env.db("recurrence-early-a.sqlite");
+    let b = env.db("recurrence-early-b.sqlite");
+    let tomorrow = chrono::Utc::now()
+        .date_naive()
+        .checked_add_days(chrono::Days::new(1))
+        .unwrap()
+        .to_string();
+    let output = ok(env.aven(
+        &a,
+        [
+            "add",
+            "early cancel",
+            "--repeat",
+            "daily",
+            "--repeat-due",
+            "same-day",
+            "--time-zone",
+            "UTC",
+            "--repeat-start-on",
+            &tomorrow,
+        ],
+    ));
+    let series_ref = output.split_whitespace().nth(1).unwrap().to_string();
+    let occurrence_ref = output
+        .split_whitespace()
+        .find_map(|part| part.strip_prefix("occurrence="))
+        .unwrap()
+        .trim_matches('"')
+        .to_string();
+    ok(env.aven(&a, ["recur", "stop", &series_ref]));
+    ok(env.aven(&a, ["edit", &occurrence_ref, "--status", "canceled"]));
+
+    sync(&env, &a, &server);
+    sync(&env, &b, &server);
+
+    for db in [&a, &b] {
+        assert_eq!(
+            query_sql_scalar(db, "SELECT outcome FROM recurrence_occurrences"),
+            "skipped"
+        );
+        assert_eq!(
+            query_sql_scalar(db, "SELECT projection_state FROM recurrence_occurrences"),
+            "resolved"
+        );
+        assert_eq!(
+            scalar_i64(db, "SELECT count(*) FROM conflicts WHERE resolved = 0"),
+            0
+        );
+    }
+}
+
+#[test]
 fn recurrence_active_stop_race_preserves_tasks_and_blocks_projection() {
     let env = TestEnv::new();
     let server = TestServer::start(&env);


### PR DESCRIPTION
## Problem

Resolving a projected occurrence whose slot hasn't started yet permanently poisons the sync queue.

Repro (hit this on my own data with v0.1.28):

1. Create a recurring task, then `recur stop` the series. The final projected occurrence remains, and deleting it is rejected with the hint **"complete or cancel the final occurrence"**.
2. Follow that hint while the occurrence's slot is still in the future (e.g. tomorrow): `aven edit <ref> --status canceled`.
3. The client records a `resolve_recurrence_occurrence` change with `resolved_at` = now, which is earlier than the slot's boundary. Sync validation rejects it:

   ```
   HTTP 400: error invalid-sync-change recurrence-resolution-before-slot
   ```

4. Since the rejected change sits at the front of the client's unsynced queue, **every subsequent change is blocked** and the daemon retries the same 400 forever. There is no way to recover from the CLI/TUI — I had to hand-delete the rows from the local `changes` table.

The same applies to completing/skipping the current projected occurrence a day early on an active series.

## Root cause

`resolve_recurrence_occurrence_in_transaction` happily resolves the currently projected occurrence regardless of date (and the stopped-series delete hint explicitly directs users to do so), but `validate_recurrence_outcome` (push) and `apply_outcome` (pull) both require `resolved_at >= slot_values(...).boundary_at`. Client and sync layer disagree, and the failure mode is a permanently stuck queue.

## Fix

Drop the `resolved_at` vs. slot-boundary ordering check on both the push-validation and pull-apply paths. `resolved_at` is still validated as a well-formed timestamp, and the slot must still be on the series lattice (`recurrence-slot-off-lattice`). Early resolution merges fine with the existing LWW rules (dual-complete already keeps the earliest `resolved_at`).

An alternative would be to reject early resolution client-side, but that would leave a stopped series' future final occurrence undeletable *and* uncancelable until its slot day arrives, contradicting the existing hint text.

## Test

Added `recurrence_resolution_before_slot_syncs_and_applies`: client A creates a daily series starting tomorrow, stops it, cancels the final (future) occurrence, and syncs; client B pulls and both converge on `outcome = skipped` with no conflicts. Fails with `recurrence-resolution-before-slot` before this change, passes after.

`cargo test -p aven-core` and the sync/recurrence integration suites pass (4 pre-existing `cli_sync` failures on my machine are unrelated — they fail on `main` too, in the `exec_sql` helper shelling out to the system `sqlite3`).