### PR TITLE
Match display refs whose project prefix carries digits

### DIFF
--- a/crates/aven-core/src/operations/projects.rs
+++ b/crates/aven-core/src/operations/projects.rs
@@ -806,7 +806,9 @@ async fn project_prefix_exists(
 
 fn normalize_prefix(prefix: &str) -> Result<String> {
     let prefix = prefix.trim().to_ascii_uppercase();
-    if (2..=8).contains(&prefix.len()) && prefix.chars().all(|ch| ch.is_ascii_alphanumeric()) {
+    if (2..=crate::projects::MAX_PROJECT_PREFIX_LEN).contains(&prefix.len())
+        && prefix.chars().all(|ch| ch.is_ascii_alphanumeric())
+    {
         Ok(prefix)
     } else {
         bail!("error invalid-project-prefix prefix={prefix:?}")

--- a/crates/aven-core/src/operations/projects.rs
+++ b/crates/aven-core/src/operations/projects.rs
@@ -806,7 +806,7 @@ async fn project_prefix_exists(
 
 fn normalize_prefix(prefix: &str) -> Result<String> {
     let prefix = prefix.trim().to_ascii_uppercase();
-    if (2..=crate::projects::MAX_PROJECT_PREFIX_LEN).contains(&prefix.len())
+    if (2..=crate::projects::MAX_EXPLICIT_PROJECT_PREFIX_LEN).contains(&prefix.len())
         && prefix.chars().all(|ch| ch.is_ascii_alphanumeric())
     {
         Ok(prefix)

--- a/crates/aven-core/src/projects.rs
+++ b/crates/aven-core/src/projects.rs
@@ -434,6 +434,8 @@ async fn restore_deleted_project(
     )))
 }
 
+pub(crate) const MAX_PROJECT_PREFIX_LEN: usize = 8;
+
 async fn unique_project_prefix(
     conn: &mut SqliteConnection,
     workspace_id: &WorkspaceId,

--- a/crates/aven-core/src/projects.rs
+++ b/crates/aven-core/src/projects.rs
@@ -434,7 +434,7 @@ async fn restore_deleted_project(
     )))
 }
 
-pub(crate) const MAX_PROJECT_PREFIX_LEN: usize = 8;
+pub(crate) const MAX_EXPLICIT_PROJECT_PREFIX_LEN: usize = 8;
 
 async fn unique_project_prefix(
     conn: &mut SqliteConnection,

--- a/crates/aven-core/src/query/search/parser.rs
+++ b/crates/aven-core/src/query/search/parser.rs
@@ -1,4 +1,4 @@
-use crate::projects::MAX_PROJECT_PREFIX_LEN;
+use crate::projects::MAX_EXPLICIT_PROJECT_PREFIX_LEN;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParsedTaskSearchQuery {
@@ -189,11 +189,12 @@ fn parse_ref_query(input: &str) -> Option<ParsedRefSearchQuery> {
     None
 }
 
-/// Alphabetic prefixes are valid regardless of length. Prefixes containing
-/// digits follow the length constraint used for explicit project prefixes.
+/// Alphabetic groups are prefix candidates regardless of length. Groups
+/// containing digits follow the length constraint for explicit project prefixes.
 fn is_project_prefix_group(group: &str) -> bool {
     group.chars().all(|ch| ch.is_ascii_alphabetic())
-        || (group.len() <= MAX_PROJECT_PREFIX_LEN && group.chars().any(|ch| ch.is_ascii_digit()))
+        || (group.len() <= MAX_EXPLICIT_PROJECT_PREFIX_LEN
+            && group.chars().any(|ch| ch.is_ascii_digit()))
 }
 
 fn suffix_has_digit(input: &str) -> bool {
@@ -277,7 +278,7 @@ mod tests {
     }
 
     #[test]
-    fn task_search_parser_supports_numeric_and_long_alphabetic_project_prefixes() {
+    fn task_search_parser_supports_numeric_project_prefixes() {
         let numeric = parse_task_search_query("0M-XYMT").ref_query.unwrap();
         assert_eq!(numeric.normalized_prefix.as_deref(), Some("0M"));
         assert_eq!(numeric.normalized_suffix, "XYMT");
@@ -289,16 +290,13 @@ mod tests {
         let long_numeric = parse_task_search_query("2FAST-7OKI").ref_query.unwrap();
         assert_eq!(long_numeric.normalized_prefix.as_deref(), Some("2FAST"));
         assert_eq!(long_numeric.normalized_suffix, "70K1");
+    }
 
-        let long_alphabetic = parse_task_search_query("BRAVO-7OKI").ref_query.unwrap();
-        assert_eq!(long_alphabetic.normalized_prefix.as_deref(), Some("BRAV0"));
-        assert_eq!(long_alphabetic.normalized_suffix, "70K1");
-
-        let hyphenated = parse_task_search_query("release-cleanup")
-            .ref_query
-            .unwrap();
-        assert_eq!(hyphenated.normalized_prefix.as_deref(), Some("RE1EASE"));
-        assert_eq!(hyphenated.normalized_suffix, "C1EANUP");
+    #[test]
+    fn task_search_parser_supports_long_alphabetic_project_prefixes() {
+        let parsed = parse_task_search_query("BRAVO-7OKI").ref_query.unwrap();
+        assert_eq!(parsed.normalized_prefix.as_deref(), Some("BRAV0"));
+        assert_eq!(parsed.normalized_suffix, "70K1");
     }
 
     #[test]

--- a/crates/aven-core/src/query/search/parser.rs
+++ b/crates/aven-core/src/query/search/parser.rs
@@ -1,3 +1,7 @@
+/// Longest prefix `unique_project_prefix` can mint: a three-character base plus
+/// a collision counter.
+const MAX_PROJECT_PREFIX_LEN: usize = 4;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParsedTaskSearchQuery {
     pub trimmed: String,
@@ -165,7 +169,7 @@ fn parse_ref_query(input: &str) -> Option<ParsedRefSearchQuery> {
     if groups.is_empty() {
         return None;
     }
-    if groups.len() >= 2 && groups[0].chars().all(|c| c.is_ascii_alphabetic()) {
+    if groups.len() >= 2 && is_project_prefix_group(groups[0]) {
         let suffix = groups[1..].join("");
         if suffix.len() >= 3 && (!has_whitespace || has_ref_marker || suffix_has_digit(&suffix)) {
             return Some(ParsedRefSearchQuery {
@@ -185,6 +189,13 @@ fn parse_ref_query(input: &str) -> Option<ParsedRefSearchQuery> {
         });
     }
     None
+}
+
+/// Project prefixes are derived from project keys, so they can carry digits
+/// (`00-main` yields `0M`) as well as a disambiguating counter (`0L2`). Only the
+/// length rules a leading group out as a prefix candidate.
+fn is_project_prefix_group(group: &str) -> bool {
+    group.len() <= MAX_PROJECT_PREFIX_LEN
 }
 
 fn suffix_has_digit(input: &str) -> bool {
@@ -265,6 +276,23 @@ mod tests {
         assert_eq!(qualified.normalized_suffix, "70K1");
 
         assert_eq!(parse_task_search_query("release cleanup").ref_query, None);
+    }
+
+    #[test]
+    fn task_search_parser_identifies_ref_shapes_for_numeric_project_prefixes() {
+        let numeric = parse_task_search_query("0M-XYMT").ref_query.unwrap();
+        assert_eq!(numeric.normalized_prefix.as_deref(), Some("0M"));
+        assert_eq!(numeric.normalized_suffix, "XYMT");
+
+        let counted = parse_task_search_query("/0L2-7OKI").ref_query.unwrap();
+        assert_eq!(counted.normalized_prefix.as_deref(), Some("012"));
+        assert_eq!(counted.normalized_suffix, "70K1");
+
+        let long_leading_group = parse_task_search_query("release-cleanup")
+            .ref_query
+            .unwrap();
+        assert_eq!(long_leading_group.normalized_prefix, None);
+        assert_eq!(long_leading_group.normalized_suffix, "RE1EASEC1EANUP");
     }
 
     #[test]

--- a/crates/aven-core/src/query/search/parser.rs
+++ b/crates/aven-core/src/query/search/parser.rs
@@ -1,6 +1,4 @@
-/// Longest prefix `unique_project_prefix` can mint: a three-character base plus
-/// a collision counter.
-const MAX_PROJECT_PREFIX_LEN: usize = 4;
+use crate::projects::MAX_PROJECT_PREFIX_LEN;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParsedTaskSearchQuery {
@@ -191,11 +189,11 @@ fn parse_ref_query(input: &str) -> Option<ParsedRefSearchQuery> {
     None
 }
 
-/// Project prefixes are derived from project keys, so they can carry digits
-/// (`00-main` yields `0M`) as well as a disambiguating counter (`0L2`). Only the
-/// length rules a leading group out as a prefix candidate.
+/// Alphabetic prefixes are valid regardless of length. Prefixes containing
+/// digits follow the length constraint used for explicit project prefixes.
 fn is_project_prefix_group(group: &str) -> bool {
-    group.len() <= MAX_PROJECT_PREFIX_LEN
+    group.chars().all(|ch| ch.is_ascii_alphabetic())
+        || (group.len() <= MAX_PROJECT_PREFIX_LEN && group.chars().any(|ch| ch.is_ascii_digit()))
 }
 
 fn suffix_has_digit(input: &str) -> bool {
@@ -279,7 +277,7 @@ mod tests {
     }
 
     #[test]
-    fn task_search_parser_identifies_ref_shapes_for_numeric_project_prefixes() {
+    fn task_search_parser_supports_numeric_and_long_alphabetic_project_prefixes() {
         let numeric = parse_task_search_query("0M-XYMT").ref_query.unwrap();
         assert_eq!(numeric.normalized_prefix.as_deref(), Some("0M"));
         assert_eq!(numeric.normalized_suffix, "XYMT");
@@ -288,11 +286,19 @@ mod tests {
         assert_eq!(counted.normalized_prefix.as_deref(), Some("012"));
         assert_eq!(counted.normalized_suffix, "70K1");
 
-        let long_leading_group = parse_task_search_query("release-cleanup")
+        let long_numeric = parse_task_search_query("2FAST-7OKI").ref_query.unwrap();
+        assert_eq!(long_numeric.normalized_prefix.as_deref(), Some("2FAST"));
+        assert_eq!(long_numeric.normalized_suffix, "70K1");
+
+        let long_alphabetic = parse_task_search_query("BRAVO-7OKI").ref_query.unwrap();
+        assert_eq!(long_alphabetic.normalized_prefix.as_deref(), Some("BRAV0"));
+        assert_eq!(long_alphabetic.normalized_suffix, "70K1");
+
+        let hyphenated = parse_task_search_query("release-cleanup")
             .ref_query
             .unwrap();
-        assert_eq!(long_leading_group.normalized_prefix, None);
-        assert_eq!(long_leading_group.normalized_suffix, "RE1EASEC1EANUP");
+        assert_eq!(hyphenated.normalized_prefix.as_deref(), Some("RE1EASE"));
+        assert_eq!(hyphenated.normalized_suffix, "C1EANUP");
     }
 
     #[test]

--- a/crates/aven-core/src/query/search_tests.rs
+++ b/crates/aven-core/src/query/search_tests.rs
@@ -1404,3 +1404,61 @@ async fn task_search_applies_project_scope_to_every_candidate_lane_before_limiti
     );
     assert_eq!(attachments[0].matched_field, SearchMatchedField::Attachment);
 }
+
+#[tokio::test]
+async fn task_search_resolves_display_refs_for_numeric_project_prefixes() {
+    let (_temp, mut conn) = test_conn().await;
+    sqlx::query(
+        "INSERT INTO projects(id, key, name, prefix, created_at, updated_at)
+         VALUES ('0000000000000002', '00-main', '00. Main', '0M', 't', 't')",
+    )
+    .execute(conn.as_mut())
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO tasks(id, title, description, project_id, status, priority,
+             created_at, updated_at, queue_activity_at)
+         VALUES ('XYMTB8W8T3NRZDXY', 'FinceptTerminal', '', '0000000000000002', 'todo', 'none', 't', 't', 't')",
+    )
+    .execute(conn.as_mut())
+    .await
+    .unwrap();
+
+    let workspace_id = crate::workspaces::default_workspace_id();
+    let preview = search_task_preview_set_in_workspace(
+        &mut conn,
+        &workspace_id,
+        TaskSearchQuery {
+            metadata: Vec::new(),
+            has_metadata: Vec::new(),
+            missing_metadata: Vec::new(),
+            text: "fin".to_string(),
+            project: None,
+            include_deleted: false,
+            limit: 10,
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(preview.items[0].display_ref, "0M-XYMT");
+
+    // Accepting a preview row re-runs the search against its display ref, so the
+    // ref lane has to recognize a prefix that carries digits.
+    let accepted = search_task_items_in_workspace(
+        &mut conn,
+        &workspace_id,
+        TaskSearchQuery {
+            metadata: Vec::new(),
+            has_metadata: Vec::new(),
+            missing_metadata: Vec::new(),
+            text: preview.items[0].display_ref.clone(),
+            project: None,
+            include_deleted: false,
+            limit: 10,
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(accepted[0].item.task.id.as_str(), "XYMTB8W8T3NRZDXY");
+    assert_eq!(accepted[0].matched_field, SearchMatchedField::Ref);
+}


### PR DESCRIPTION
## Problem

In the TUI, pressing enter on a search result lands on the empty **"no search results"** view for every task that lives in a project whose prefix contains a digit.

Repro (hit this on my own data with v0.1.28):

1. Create a project whose key starts with digits, e.g. `00-main`. `prefix_base` derives the prefix from the first character of each key word, so the project gets prefix `0M` and its tasks display as `0M-XYMT`.
2. Open the TUI, press `/`, and type something that matches such a task. The preview lists it fine.
3. Press enter. The list switches to the search view with **no results**, even though the row was right there a keystroke earlier.

Same thing from the CLI:

```
$ aven search fin
0M-XYMT  FinceptTerminal ...      # found

$ aven search 0M-XYMT
                                  # nothing
```

Alphabetic prefixes (`AVN-RHGF`) are unaffected, which is why this went unnoticed.

## Root cause

Accepting a search result re-runs the search against the result's display ref (`App::accept_search_result` → `accept_search_input(result.display_ref)`), so the ref lane has to be able to parse `PREFIX-SUFFIX` back.

`parse_ref_query` only treated a leading group as a project prefix when it was entirely alphabetic:

```rust
if groups.len() >= 2 && groups[0].chars().all(|c| c.is_ascii_alphabetic()) {
```

But `prefix_base` takes the first character of each dash-separated key word, so digits are perfectly ordinary in a prefix (`00-main` → `0M`, `01-loop` → `0L`, `03-lge` → `0L2`). For those refs the branch was skipped and the query fell through to the suffix-only branch, where `0M-XYMT` collapses into `0MXYMT` — which never prefix-matches the task id `XYMTB8W8T3NRZDXY`. No ref evidence, no results, empty view.

`refs.rs::split_ref` (used by `show`, `edit`, …) has always split on the first `-` without an alphabetic requirement, so `aven show 0M-XYMT` works and only search disagreed.

## Fix

Treat any leading group of at most four characters as a prefix candidate. `unique_project_prefix` mints at most a three-character base plus a collision counter, so four is the real ceiling, and the length bound keeps ordinary hyphenated prose (`release-cleanup`) out of the ref lane the way the alphabetic check used to.

The prefix stays a hard filter against the project prefix in `score_ref_lane`, so `/WRONG-7KQ9` still returns nothing.

## Test

- `task_search_parser_identifies_ref_shapes_for_numeric_project_prefixes` covers `0M-XYMT`, `/0L2-7OKI`, and that `release-cleanup` still parses as suffix-only.
- `task_search_resolves_display_refs_for_numeric_project_prefixes` seeds a `0M`-prefixed project and walks the actual TUI round trip: preview a task, then re-search its `display_ref` and assert the task comes back with `matched_field = Ref`.

`cargo test`, `cargo clippy --all-targets`, and `cargo fmt --check` pass. The 8 failures I see in `cli_sync` / `cli_workspaces` / `cli_daemon_sync` / `cli_inference_errors` are pre-existing on `main` — the `exec_sql` helper shells out to my system `sqlite3`, which has no fts5 module.

I also re-ran every display ref in my own workspace (186 of them) through `aven search` and they all resolve now. The only refs that still don't are recurrence series refs (`RCR-…`), which are a separate matter — happy to send that as its own PR.
