### PR TITLE
Resolve recurrence series refs from search

### DIFF
--- a/crates/aven-core/src/operations/recurrence.rs
+++ b/crates/aven-core/src/operations/recurrence.rs
@@ -19,8 +19,8 @@ use crate::mutation::apply_field_value_in_workspace;
 use crate::projects::resolve_or_create_project_in_workspace;
 use crate::recurrence::{
     RecurrenceDuePolicy, RecurrenceOutcome, RecurrenceProjectionState, RecurrenceSchedule,
-    RecurrenceSeriesId, RecurrenceSeriesState, derive_occurrence_identity, next_slot_after,
-    projection_slot_at, recurrence_series_display_ref, slot_cutoff, slot_values,
+    RecurrenceSeriesId, RecurrenceSeriesState, SERIES_REF_PREFIX, derive_occurrence_identity,
+    next_slot_after, projection_slot_at, recurrence_series_display_ref, slot_cutoff, slot_values,
 };
 use crate::refs::get_task_in_workspace;
 use crate::task_fields::TaskField;
@@ -33,7 +33,6 @@ use crate::workspaces::Workspace;
 mod tests;
 
 const RECONCILE_ATTEMPTS: usize = 3;
-const SERIES_REF_PREFIX: &str = "RCR";
 const SERIES_TEMPLATE_FIELDS: &[&str] = &[
     "title",
     "description",

--- a/crates/aven-core/src/query/recurrence_tests.rs
+++ b/crates/aven-core/src/query/recurrence_tests.rs
@@ -3,7 +3,9 @@ use sqlx::Connection;
 
 use super::*;
 use crate::operations::{CreateRecurrenceSeriesParams, RecurrenceSeriesDraft};
-use crate::query::{SortDirection, TaskFilters, TaskQueryMode, TaskSearchQuery, TaskSort};
+use crate::query::{
+    SearchMatchedField, SortDirection, TaskFilters, TaskQueryMode, TaskSearchQuery, TaskSort,
+};
 use crate::recurrence::{
     RecurrenceDuePolicy, RecurrenceOutcome, RecurrenceRule, RecurrenceSchedule, TimeZoneId,
 };
@@ -751,4 +753,50 @@ async fn recurrence_hydration_statement_shapes_stay_bounded() {
     assert_eq!(items.len(), 24);
     assert!(items.iter().all(|item| item.recurrence.is_some()));
     assert!(conn.cached_statements_size() <= 16);
+}
+
+#[tokio::test]
+async fn search_resolves_recurrence_series_refs_to_their_occurrences() {
+    let (_temp, database, workspace) = setup().await;
+    let created = create(&database, &workspace, "series ref fixture", 6).await;
+    let series_ref = created.series_ref.clone();
+    let suffix = series_ref.split_once('-').unwrap().1.to_string();
+
+    let search = |text: String| {
+        let database = database.clone();
+        let workspace_id = workspace.id.clone();
+        async move {
+            let mut conn = database.acquire_writer().await.unwrap();
+            super::super::search::search_task_items_in_workspace(
+                &mut conn,
+                &workspace_id,
+                TaskSearchQuery {
+                    metadata: Vec::new(),
+                    has_metadata: Vec::new(),
+                    missing_metadata: Vec::new(),
+                    text,
+                    project: None,
+                    include_deleted: false,
+                    limit: 20,
+                },
+            )
+            .await
+            .unwrap()
+        }
+    };
+
+    // The series ref is what the UI shows for a recurring row, so searching it
+    // has to land on the occurrence the series currently projects.
+    let qualified = search(series_ref).await;
+    assert_eq!(qualified.len(), 1);
+    assert_eq!(qualified[0].item.task.id, created.task.id);
+    assert_eq!(qualified[0].matched_field, SearchMatchedField::Ref);
+
+    let bare = search(suffix.clone()).await;
+    assert_eq!(bare.len(), 1);
+    assert_eq!(bare[0].item.task.id, created.task.id);
+    assert_eq!(bare[0].matched_field, SearchMatchedField::Ref);
+
+    let wrong_prefix = search(format!("/APP-{suffix}")).await;
+    assert!(wrong_prefix.is_empty());
 }

--- a/crates/aven-core/src/query/search.rs
+++ b/crates/aven-core/src/query/search.rs
@@ -661,9 +661,9 @@ async fn load_series_ref_search_documents(
     query.push_bind(project_id);
     query.push(") AND ");
     query.push(super::fragments::ordinary_task_clause("t"));
-    query.push(" AND ro.series_id LIKE ");
-    query.push_bind(suffix);
-    query.push(" || '%' ORDER BY t.updated_at DESC, t.id");
+    query.push(" AND ro.series_id GLOB ");
+    query.push_bind(format!("{suffix}*"));
+    query.push(" ORDER BY t.updated_at DESC, t.id");
 
     let rows = query.build().fetch_all(&mut *conn).await?;
     search_documents_from_rows(rows, display_refs)

--- a/crates/aven-core/src/query/search.rs
+++ b/crates/aven-core/src/query/search.rs
@@ -125,6 +125,15 @@ struct SearchDocument {
     labels_text: String,
     notes_text: String,
     attachments_text: String,
+    series: Option<DocumentSeries>,
+}
+
+/// Recurrence identity of an occurrence task. The ref lane reads it so a series
+/// ref like `RCR-NP3S` — the ref the UI shows for a recurring row — resolves to
+/// the occurrences that series projects.
+struct DocumentSeries {
+    id: String,
+    display_ref: String,
 }
 
 struct ScoredDocument {
@@ -551,6 +560,16 @@ async fn load_candidate_search_documents(
         )
         .await?;
         merge_search_documents(&mut documents, ref_documents);
+        let series_documents = load_series_ref_search_documents(
+            conn,
+            workspace_id,
+            project_id,
+            include_deleted,
+            ref_query,
+            display_refs,
+        )
+        .await?;
+        merge_search_documents(&mut documents, series_documents);
     }
     let attachment_documents = load_attachment_text_search_documents(
         conn,
@@ -563,6 +582,9 @@ async fn load_candidate_search_documents(
     .await?;
     merge_search_documents(&mut documents, attachment_documents);
     attach_attachment_search_text(conn, workspace_id.as_str(), &mut documents).await?;
+    if parsed.ref_query.is_some() {
+        attach_recurrence_series_refs(conn, workspace_id, &mut documents).await?;
+    }
     Ok(documents)
 }
 
@@ -598,6 +620,75 @@ async fn load_ref_search_documents(
     .fetch_all(&mut *conn)
     .await?;
     search_documents_from_rows(rows, display_refs)
+}
+
+/// Suffix a series ref query addresses, or `None` when the query names a project
+/// prefix and so cannot be a series ref.
+fn series_ref_suffix(ref_query: &parser::ParsedRefSearchQuery) -> Option<&str> {
+    match ref_query.normalized_prefix.as_deref() {
+        Some(prefix) if prefix != crate::recurrence::SERIES_REF_PREFIX => None,
+        _ => Some(&ref_query.normalized_suffix),
+    }
+}
+
+async fn load_series_ref_search_documents(
+    conn: &mut SqliteConnection,
+    workspace_id: &WorkspaceId,
+    project_id: Option<&ProjectId>,
+    include_deleted: bool,
+    ref_query: &parser::ParsedRefSearchQuery,
+    display_refs: &DisplayRefContext,
+) -> Result<Vec<SearchDocument>> {
+    let Some(suffix) = series_ref_suffix(ref_query) else {
+        return Ok(Vec::new());
+    };
+    let mut query = QueryBuilder::<Sqlite>::new(
+        "SELECT t.id, t.workspace_id, t.title, t.description, t.project_id,
+         p.key AS project_key, p.name AS project_name, p.prefix AS project_prefix,
+         t.status, t.priority, t.source, t.created_at, t.updated_at, t.queue_activity_at, t.available_at, t.due_on, t.deleted, t.is_epic,
+         '' AS fts_labels, '' AS fts_notes
+         FROM recurrence_occurrences ro
+         JOIN tasks t ON t.workspace_id = ro.workspace_id AND t.id = ro.task_id
+         JOIN projects p ON p.workspace_id = t.workspace_id AND p.id = t.project_id
+         WHERE ro.workspace_id = ",
+    );
+    query.push_bind(workspace_id);
+    query.push(" AND (");
+    query.push_bind(include_deleted);
+    query.push(" OR t.deleted = 0) AND (");
+    query.push_bind(project_id.is_none());
+    query.push(" OR t.project_id = ");
+    query.push_bind(project_id);
+    query.push(") AND ");
+    query.push(super::fragments::ordinary_task_clause("t"));
+    query.push(" AND ro.series_id LIKE ");
+    query.push_bind(suffix);
+    query.push(" || '%' ORDER BY t.updated_at DESC, t.id");
+
+    let rows = query.build().fetch_all(&mut *conn).await?;
+    search_documents_from_rows(rows, display_refs)
+}
+
+async fn attach_recurrence_series_refs(
+    conn: &mut SqliteConnection,
+    workspace_id: &WorkspaceId,
+    documents: &mut [SearchDocument],
+) -> Result<()> {
+    let task_ids = documents
+        .iter()
+        .map(|document| document.task.id.clone())
+        .collect::<Vec<_>>();
+    let mut summaries =
+        super::recurrence::task_recurrence_summaries(conn, workspace_id, &task_ids).await?;
+    for document in documents {
+        document.series = summaries
+            .remove(&document.task.id)
+            .map(|summary| DocumentSeries {
+                id: summary.series_id.to_string(),
+                display_ref: summary.series_ref,
+            });
+    }
+    Ok(())
 }
 
 fn merge_search_documents(documents: &mut Vec<SearchDocument>, incoming: Vec<SearchDocument>) {
@@ -678,6 +769,7 @@ fn search_documents_from_rows(
                 task,
                 display_ref,
                 project_name,
+                series: None,
             }
         })
         .collect())
@@ -928,17 +1020,44 @@ fn score_ref_lane(
     document: &SearchDocument,
     ref_query: &parser::ParsedRefSearchQuery,
 ) -> Option<i64> {
+    // Option ordering keeps whichever identity the query addresses more closely.
+    score_task_ref_lane(document, ref_query).max(score_series_ref_lane(document, ref_query))
+}
+
+fn score_task_ref_lane(
+    document: &SearchDocument,
+    ref_query: &parser::ParsedRefSearchQuery,
+) -> Option<i64> {
     if let Some(prefix) = ref_query.normalized_prefix.as_deref()
         && normalize_ref_query(&document.task.project_prefix) != prefix
     {
         return None;
     }
-    let normalized_id = normalize_ref_query(&document.task.id);
+    score_ref_identity(&document.task.id, &document.display_ref, ref_query)
+}
+
+fn score_series_ref_lane(
+    document: &SearchDocument,
+    ref_query: &parser::ParsedRefSearchQuery,
+) -> Option<i64> {
+    let suffix = series_ref_suffix(ref_query)?;
+    let series = document.series.as_ref()?;
+    normalize_ref_query(&series.id)
+        .starts_with(suffix)
+        .then(|| score_ref_identity(&series.id, &series.display_ref, ref_query))
+        .flatten()
+}
+
+fn score_ref_identity(
+    id: &str,
+    display_ref: &str,
+    ref_query: &parser::ParsedRefSearchQuery,
+) -> Option<i64> {
+    let normalized_id = normalize_ref_query(id);
     if !normalized_id.starts_with(&ref_query.normalized_suffix) {
         return None;
     }
-    let display_suffix_len = document
-        .display_ref
+    let display_suffix_len = display_ref
         .rsplit_once('-')
         .map(|(_, suffix)| normalize_ref_query(suffix).len())
         .unwrap_or(0);

--- a/crates/aven-core/src/recurrence.rs
+++ b/crates/aven-core/src/recurrence.rs
@@ -49,6 +49,10 @@ impl RecurrenceSeriesId {
     }
 }
 
+/// Prefix every recurrence series display ref carries, in place of the project
+/// prefix a task ref uses.
+pub(crate) const SERIES_REF_PREFIX: &str = "RCR";
+
 pub(crate) fn recurrence_series_display_ref(
     series_id: &RecurrenceSeriesId,
     ids: &[RecurrenceSeriesId],
@@ -66,7 +70,7 @@ pub(crate) fn recurrence_series_display_ref(
         .max()
         .unwrap_or(0);
     let length = 4.max(shared.saturating_add(1)).min(id.len());
-    format!("RCR-{}", &id[..length])
+    format!("{SERIES_REF_PREFIX}-{}", &id[..length])
 }
 
 impl Default for RecurrenceSeriesId {


### PR DESCRIPTION
## Problem

A recurring row advertises its series ref in the task list preview:

```
↻ RCR-NP3S · slot 2026-08-19 · weekdays · active
```

Every other command takes that ref — `aven recur show RCR-NP3S` resolves it, and `resolve_recurrence_ref` accepts it wherever a series is named. Search does not:

```
$ aven recur show RCR-NP3S
RCR-NP3S state=active rule="weekdays" ... title="오전 메일 확인"

$ aven search RCR-NP3S
                                  # nothing
```

Same in the TUI: typing a series ref you just read off the screen lands on the empty "no search results" view. In my own workspace 23 of 186 display refs were unsearchable, all of them series refs.

## Root cause

The ref lane only ever had one identity to match against: `score_ref_lane` compares the query suffix to `task.id`, and gates on `normalize_ref_query(task.project_prefix) == prefix`. `RCR` is not a project prefix and a series id is not a task id, so a series ref fails both halves — no ref evidence, no candidates, empty result.

`resolve_recurrence_ref` already models the right shape: the hint must be absent or `RCR`, and the suffix matches `recurrence_series.id`.

## Fix

Give the ref lane a second identity.

- `series_ref_suffix` returns the suffix a series ref addresses — when the query names no prefix, or names `RCR` — and `None` when it names a project prefix.
- `load_series_ref_search_documents` loads the occurrence tasks whose series id carries that suffix, under the same visibility rules the task ref lane already applies (`ordinary_task_clause`, so paused and archived projections stay out) and the same project/deleted scoping.
- `attach_recurrence_series_refs` hangs each candidate's series id and series display ref off the document, reusing `task_recurrence_summaries` — the same call the preview path already makes.
- `score_series_ref_lane` scores that identity; `score_ref_lane` keeps whichever of the two identities scores higher.

Recurrence grouping then collapses the matched occurrences into the single row callers expect, so `search RCR-NP3S` returns exactly the recurring row, and a bare suffix (`NP3S`) works too, matching how bare suffixes already address task ids.

Two things moved rather than changed: the scoring math is now `score_ref_identity`, shared by both lanes so a ref weighs the same either way (the task lane's behaviour, including the `/WRONG-7KQ9` rejection, is unchanged), and `SERIES_REF_PREFIX` moved from `operations::recurrence` to `recurrence`, next to the display-ref formatter that mints it.

## Test

`search_resolves_recurrence_series_refs_to_their_occurrences` creates a series and searches its ref three ways: qualified (`RCR-…`), bare suffix, and a wrong prefix (`/APP-…`) that must stay empty. It fails on `main` with 0 results.

`cargo test`, `cargo clippy --all-targets`, and `cargo fmt --check` pass. The 8 failures I see in `cli_sync` / `cli_workspaces` / `cli_daemon_sync` / `cli_inference_errors` are pre-existing on `main` — the `exec_sql` helper shells out to my system `sqlite3`, which has no fts5 module.

I also re-ran all 186 display refs in my own workspace through `aven search`; every one resolves now.

Independent of #13 (that one is the parser, this one is the lane), though both came out of the same "enter on a search result shows no results" report.
