### PR TITLE
Activate sidebar rows from Enter again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ description: Release notes for aven.
 
 ## Unreleased
 
+- Fix: Pressing `Enter` on a highlighted [sidebar](/tui/) row selects that view, project, or workspace again instead of opening the detail of the task selected in the list.
+
 ## v0.1.32 (2026-08-24)
 
 - Running `aven` with no command opens the [TUI](/tui/) directly. Global options such as `--db` and `--workspace` still apply.

--- a/src/tui/app_dispatch.rs
+++ b/src/tui/app_dispatch.rs
@@ -2470,7 +2470,21 @@ impl App {
         {
             return Ok(Err(reason.message().to_string()));
         }
-        let target = if let CommandSituation::SidebarProject { project } = snapshot.situation()
+        let situation = snapshot.situation();
+        let target = if action == Action::ToggleDetail
+            && let Some(sidebar) = snapshot.sidebar_target().cloned()
+        {
+            if let crate::tui::event::SidebarCommandTarget::Project(project) = &sidebar
+                && !self
+                    .store
+                    .projects
+                    .iter()
+                    .any(|candidate| candidate.key == project.as_str())
+            {
+                return Ok(Err("captured sidebar project is stale".to_string()));
+            }
+            ResolvedCommandTarget::Sidebar(sidebar)
+        } else if let CommandSituation::SidebarProject { project } = situation
             && matches!(
                 action,
                 Action::BeginScopeProject
@@ -2479,7 +2493,8 @@ impl App {
                     | Action::BeginAddProjectPath
                     | Action::BeginRemoveProjectPath
                     | Action::BeginAddTask
-            ) {
+            )
+        {
             if !self
                 .store
                 .projects
@@ -2872,6 +2887,13 @@ impl App {
                 }
                 self.begin_unlink_captured_relationship(snapshot, section, &related)
                     .await?
+            }
+            ResolvedCommandTarget::Sidebar(sidebar) => {
+                if command.action != Action::ToggleDetail {
+                    self.set_warning("captured sidebar command is invalid");
+                    return Ok(());
+                }
+                self.apply_sidebar_command_target(sidebar).await?;
             }
             ResolvedCommandTarget::SidebarProject(project) => match command.action {
                 Action::BeginScopeProject => {

--- a/src/tui/app_navigation.rs
+++ b/src/tui/app_navigation.rs
@@ -288,6 +288,32 @@ impl App {
             .selected_sidebar()
             .and_then(|index| self.store.sidebar_entries.get(index))
             .and_then(|entry| entry.target.clone());
+        self.apply_sidebar_target(target).await
+    }
+
+    pub(super) async fn apply_sidebar_command_target(
+        &mut self,
+        target: crate::tui::event::SidebarCommandTarget,
+    ) -> Result<()> {
+        use crate::tui::event::SidebarCommandTarget;
+        use crate::tui::store::{SidebarEntryTarget, TaskScopeTarget};
+
+        let target = match target {
+            SidebarCommandTarget::View(view) => SidebarEntryTarget::View(view),
+            SidebarCommandTarget::Project(project) => {
+                SidebarEntryTarget::Scope(TaskScopeTarget::Project(project))
+            }
+            SidebarCommandTarget::Workspace => {
+                SidebarEntryTarget::Scope(TaskScopeTarget::Workspace)
+            }
+        };
+        self.apply_sidebar_target(Some(target)).await
+    }
+
+    async fn apply_sidebar_target(
+        &mut self,
+        target: Option<crate::tui::store::SidebarEntryTarget>,
+    ) -> Result<()> {
         match target {
             Some(crate::tui::store::SidebarEntryTarget::View(view)) => self.show_view(view).await?,
             Some(crate::tui::store::SidebarEntryTarget::Scope(scope)) => {

--- a/src/tui/app_tests/keyboard_dispatch.rs
+++ b/src/tui/app_tests/keyboard_dispatch.rs
@@ -179,6 +179,208 @@ async fn sidebar_selection_survives_focus_changes() {
 }
 
 #[tokio::test]
+async fn sidebar_enter_selects_the_highlighted_view() {
+    let mut app = test_app().await;
+    let view_index = app
+        .store
+        .sidebar_entries
+        .iter()
+        .position(|entry| {
+            matches!(
+                &entry.target,
+                Some(SidebarEntryTarget::View(TaskQuery::Open))
+            )
+        })
+        .unwrap();
+    app.list.focus_sidebar();
+    app.list.select_sidebar(Some(view_index));
+
+    app.handle_normal_key(KeyCode::Enter).await.unwrap();
+
+    assert_eq!(app.store.view_state.query, TaskQuery::Open);
+    assert_eq!(app.list.focus(), Focus::Tasks);
+    assert!(!app.detail.is_active());
+    assert_eq!(toast_message(&app), None);
+}
+
+#[tokio::test]
+async fn sidebar_enter_selects_the_highlighted_project_scope() {
+    let mut app = test_app().await;
+    app.store
+        .create_project("Mobile App".to_string())
+        .await
+        .unwrap();
+    app.refresh().await.unwrap();
+
+    let project_index = app
+        .store
+        .sidebar_entries
+        .iter()
+        .position(|entry| {
+            matches!(
+                &entry.target,
+                Some(SidebarEntryTarget::Scope(TaskScopeTarget::Project(project)))
+                    if project == "mobile-app"
+            )
+        })
+        .unwrap();
+    app.list.focus_sidebar();
+    app.list.select_sidebar(Some(project_index));
+
+    app.handle_normal_key(KeyCode::Enter).await.unwrap();
+
+    assert_eq!(
+        app.store.view_state.scope,
+        TaskScope::Project("mobile-app".to_string())
+    );
+    assert_eq!(app.list.focus(), Focus::Tasks);
+    assert!(!app.detail.is_active());
+    assert_eq!(toast_message(&app), None);
+}
+
+#[tokio::test]
+async fn sidebar_enter_selects_a_view_with_no_tasks_in_the_current_view() {
+    let mut app = test_app().await;
+    app.show_view(TaskQuery::Conflicts).await.unwrap();
+    assert!(app.store.tasks.is_empty());
+
+    let view_index = app
+        .store
+        .sidebar_entries
+        .iter()
+        .position(|entry| {
+            matches!(
+                &entry.target,
+                Some(SidebarEntryTarget::View(TaskQuery::Open))
+            )
+        })
+        .unwrap();
+    app.list.focus_sidebar();
+    app.list.select_sidebar(Some(view_index));
+
+    app.handle_normal_key(KeyCode::Enter).await.unwrap();
+
+    assert_eq!(app.store.view_state.query, TaskQuery::Open);
+    assert_eq!(app.list.focus(), Focus::Tasks);
+    assert!(!app.detail.is_active());
+    assert_eq!(toast_message(&app), None);
+}
+
+#[tokio::test]
+async fn sidebar_enter_selects_the_highlighted_workspace_scope() {
+    let mut app = test_app().await;
+    app.store
+        .create_project("Mobile App".to_string())
+        .await
+        .unwrap();
+    app.show_scope(TaskScopeTarget::Project("mobile-app".to_string()))
+        .await
+        .unwrap();
+
+    let workspace_index = app
+        .store
+        .sidebar_entries
+        .iter()
+        .position(|entry| {
+            matches!(
+                &entry.target,
+                Some(SidebarEntryTarget::Scope(TaskScopeTarget::Workspace))
+            )
+        })
+        .unwrap();
+    app.list.focus_sidebar();
+    app.list.select_sidebar(Some(workspace_index));
+
+    app.handle_normal_key(KeyCode::Enter).await.unwrap();
+
+    assert_eq!(app.store.view_state.scope, TaskScope::Workspace);
+    assert_eq!(app.list.focus(), Focus::Tasks);
+    assert!(!app.detail.is_active());
+    assert_eq!(toast_message(&app), None);
+}
+
+#[tokio::test]
+async fn sidebar_detail_command_is_available_without_a_selected_task() {
+    let mut app = test_app().await;
+    app.show_view(TaskQuery::Conflicts).await.unwrap();
+    assert!(app.store.tasks.is_empty());
+
+    let view_index = app
+        .store
+        .sidebar_entries
+        .iter()
+        .position(|entry| {
+            matches!(
+                &entry.target,
+                Some(SidebarEntryTarget::View(TaskQuery::Open))
+            )
+        })
+        .unwrap();
+    app.list.focus_sidebar();
+    app.list.select_sidebar(Some(view_index));
+    let snapshot = app.capture_command_session(None);
+    let command = crate::tui::event::COMMANDS
+        .iter()
+        .find(|command| command.action == Action::ToggleDetail)
+        .unwrap();
+
+    assert_eq!(
+        crate::tui::event::command_availability(
+            crate::tui::event::CatalogCommand::BuiltIn(command),
+            &snapshot,
+            &[],
+        ),
+        crate::tui::event::CommandAvailability::Ready
+    );
+}
+
+#[tokio::test]
+async fn captured_sidebar_detail_uses_the_captured_row() {
+    let mut app = test_app().await;
+    let open_index = app
+        .store
+        .sidebar_entries
+        .iter()
+        .position(|entry| {
+            matches!(
+                &entry.target,
+                Some(SidebarEntryTarget::View(TaskQuery::Open))
+            )
+        })
+        .unwrap();
+    let inbox_index = app
+        .store
+        .sidebar_entries
+        .iter()
+        .position(|entry| {
+            matches!(
+                &entry.target,
+                Some(SidebarEntryTarget::View(TaskQuery::Inbox))
+            )
+        })
+        .unwrap();
+    app.list.focus_sidebar();
+    app.list.select_sidebar(Some(open_index));
+    let snapshot = app.capture_command_session(None);
+    let command = crate::tui::event::COMMANDS
+        .iter()
+        .find(|command| command.action == Action::ToggleDetail)
+        .unwrap();
+    let resolved = app
+        .resolve_builtin_command(&snapshot, command)
+        .await
+        .unwrap()
+        .unwrap();
+
+    app.list.select_sidebar(Some(inbox_index));
+    app.execute_resolved_builtin(resolved, &snapshot)
+        .await
+        .unwrap();
+
+    assert_eq!(app.store.view_state.query, TaskQuery::Open);
+}
+
+#[tokio::test]
 async fn sidebar_toggle_shortcut_expands_task_list_and_restores_sidebar_focus() {
     let mut app = test_app().await;
     app.list.focus_sidebar();

--- a/src/tui/event/command_query.rs
+++ b/src/tui/event/command_query.rs
@@ -144,6 +144,8 @@ pub(crate) fn command_availability(
             });
     };
     let domain = snapshot.routing_domain();
+    let activates_sidebar =
+        spec.action == Action::ToggleDetail && snapshot.sidebar_target().is_some();
     if spec.scope_policy() == CommandScopePolicy::ListOnly && domain != super::RoutingDomain::Normal
     {
         return disabled("available only in the task list".to_string());
@@ -211,7 +213,7 @@ pub(crate) fn command_availability(
         BulkSupport::SingleOnly(_) if marked > 1 => {
             return disabled("requires one task".to_string());
         }
-        BulkSupport::SingleOnly(_) | BulkSupport::Focused if !has_primary => {
+        BulkSupport::SingleOnly(_) | BulkSupport::Focused if !has_primary && !activates_sidebar => {
             return disabled("requires a selected task".to_string());
         }
         BulkSupport::BulkControl if spec.action == Action::ClearMarks && marked == 0 => {

--- a/src/tui/event/session.rs
+++ b/src/tui/event/session.rs
@@ -203,6 +203,18 @@ impl CommandSessionSnapshot {
             _ => None,
         }
     }
+
+    pub(crate) fn sidebar_target(&self) -> Option<&SidebarCommandTarget> {
+        match &self.surface {
+            CommandSurfaceSnapshot::List {
+                focused_sidebar, ..
+            }
+            | CommandSurfaceSnapshot::RecurrenceList {
+                focused_sidebar, ..
+            } => focused_sidebar.as_ref(),
+            CommandSurfaceSnapshot::Detail { .. } | CommandSurfaceSnapshot::AddTaskOnly => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -215,6 +227,7 @@ pub(crate) enum ResolvedCommandTarget {
         related: TaskId,
         section: DetailSection,
     },
+    Sidebar(SidebarCommandTarget),
     SidebarProject(String),
     Attachment {
         owner: TaskId,


### PR DESCRIPTION
Since v0.1.32, pressing `Enter` on a highlighted sidebar row no longer selects that view/project/workspace — it opens the detail of whatever task is selected in the task list instead. There is no keyboard path left to switch views from the sidebar.

### Reproduce (v0.1.32)

1. Open the TUI, press `←`/`h` to focus the sidebar (the highlight moves to `Queue` as expected).
2. Press `↓`/`j` to highlight `All`.
3. Press `Enter`.

Expected: the task list switches to the `All` view.
Actual: the header still shows `view queue` and the detail pane opens for the task that was selected in the list. The same happens for `PROJECTS` and `SCOPE` rows.

### Cause

`2114768` routes every built-in command through the captured-session pipeline in `resolve_builtin_command`. `Enter` maps to `Action::ToggleDetail`, whose `target_policy()` is `CommandTargetPolicy::Focused`, so it resolves to the task list selection and `execute_tasks_command` calls `show_detail(0)` unconditionally. The `Focus::Sidebar` branch of `activate_or_toggle_detail` is never reached.

`resolve_builtin_command` only special-cases `CommandSituation::SidebarProject` for the project-management actions; `SidebarView` and `SidebarWorkspace` are constructed but never consulted there.

Before v0.1.32 `execute_command_handler` was just `self.execute(action)`, so the sidebar branch ran.

### Fix

Resolve `ToggleDetail` to `ResolvedCommandTarget::None` when the captured situation is a sidebar row, so it dispatches through `activate_or_toggle_detail` and applies the highlighted sidebar selection. Task-list `Enter` is unchanged.

### Tests

Three regression tests in `keyboard_dispatch.rs` (view row, project scope row, and a sidebar row selected while the current view is empty — that last one previously hit the "requires a selected task" path). All three fail on `main` and pass with the fix; `cargo test --lib` is green (1717 passed) and `cargo clippy --all-targets` is clean.