### PR TITLE
Fix sync of recurrence occurrences projected into a deleted project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ description: Release notes for aven.
 
 ## Unreleased
 
+- Fix: Recurring task occurrences that are projected into a deleted project now sync to other clients instead of stopping their sync with `payload missing project_key`.
+
 ## v0.1.32 (2026-08-24)
 
 - Running `aven` with no command opens the [TUI](/tui/) directly. Global options such as `--db` and `--workspace` still apply.

--- a/crates/aven-core/src/sync/apply/project.rs
+++ b/crates/aven-core/src/sync/apply/project.rs
@@ -145,10 +145,20 @@ pub(super) async fn ensure_project_for_payload(
     project_id: &ProjectId,
     change: &ChangeWire,
 ) -> Result<ProjectId> {
-    if change.payload.get("series_id").is_some()
-        && let Some(existing_id) = live_project_by_id(conn, workspace_id, project_id).await?
-    {
-        return Ok(existing_id);
+    if change.payload.get("series_id").is_some() {
+        if let Some(existing_id) = live_project_by_id(conn, workspace_id, project_id).await? {
+            return Ok(existing_id);
+        }
+        if let Some(local_id) = project_id_alias(conn, workspace_id, project_id).await? {
+            return Ok(local_id);
+        }
+        // Recurrence occurrence payloads carry only the series' project_id. When
+        // that project was deleted locally (soft-deleted because tasks still
+        // reference it) the originating client still projected into it, so
+        // mirror that instead of failing the whole sync page.
+        if deleted_project_by_id(conn, workspace_id, project_id).await? {
+            return Ok(project_id.clone());
+        }
     }
     let key = str_payload(&change.payload, "project_key")?;
     let name = str_payload(&change.payload, "project_name").unwrap_or_else(|_| key.clone());

--- a/tests/cli_sync.rs
+++ b/tests/cli_sync.rs
@@ -3825,6 +3825,87 @@ fn recurrence_same_slot_materialization_and_retries_are_idempotent() {
 }
 
 #[test]
+fn recurrence_occurrence_into_deleted_project_syncs_to_other_clients() {
+    let env = TestEnv::new();
+    let server = TestServer::start(&env);
+    let a = env.db("recurrence-deleted-project-a.sqlite");
+    let b = env.db("recurrence-deleted-project-b.sqlite");
+    let today = chrono::Utc::now().date_naive().to_string();
+    let output = ok(env.aven(
+        &a,
+        [
+            "add",
+            "deleted project occurrence",
+            "--project",
+            "app",
+            "--repeat",
+            "daily",
+            "--repeat-due",
+            "same-day",
+            "--time-zone",
+            "UTC",
+            "--repeat-start-on",
+            &today,
+        ],
+    ));
+    let occurrence_ref = output
+        .split_whitespace()
+        .find_map(|part| part.strip_prefix("occurrence="))
+        .unwrap()
+        .trim_matches('"')
+        .to_string();
+    sync(&env, &a, &server);
+    sync(&env, &b, &server);
+
+    // The project still has tasks, so deleting it soft-deletes the row on every client.
+    ok(env.aven(&b, ["project", "delete", "app"]));
+    sync(&env, &b, &server);
+    sync(&env, &a, &server);
+    let project_id = query_sql_scalar(&a, "SELECT id FROM projects WHERE key = 'app'");
+    for db in [&a, &b] {
+        assert_eq!(
+            scalar_i64(db, "SELECT deleted FROM projects WHERE key = 'app'"),
+            1
+        );
+    }
+
+    // Completing the occurrence projects the next one into the deleted project.
+    ok(env.aven(&a, ["edit", &occurrence_ref, "--status", "done"]));
+    assert_eq!(scalar_i64(&a, "SELECT count(*) FROM tasks"), 2);
+    sync(&env, &a, &server);
+
+    // The projected create_task carries no project_key, so B must resolve the
+    // deleted project by id instead of rejecting the whole page.
+    sync(&env, &b, &server);
+    assert_eq!(scalar_i64(&b, "SELECT count(*) FROM tasks"), 2);
+    assert_eq!(
+        query_sql_scalar(&b, "SELECT group_concat(DISTINCT project_id) FROM tasks"),
+        project_id
+    );
+    assert_eq!(
+        scalar_i64(
+            &b,
+            "SELECT count(*) FROM projects WHERE key = 'app' AND deleted = 1"
+        ),
+        1
+    );
+    assert_eq!(
+        scalar_i64(&b, "SELECT count(*) FROM changes WHERE server_seq IS NULL"),
+        0
+    );
+    assert_eq!(
+        query_sql_scalar(
+            &a,
+            "SELECT group_concat(slot_on || ':' || task_id, ',') FROM recurrence_occurrences ORDER BY slot_on",
+        ),
+        query_sql_scalar(
+            &b,
+            "SELECT group_concat(slot_on || ':' || task_id, ',') FROM recurrence_occurrences ORDER BY slot_on",
+        )
+    );
+}
+
+#[test]
 fn recurrence_dual_complete_merges_earliest_completion() {
     let env = TestEnv::new();
     let server = TestServer::start(&env);


### PR DESCRIPTION
Fixes #15

## Problem

When a recurring series keeps projecting occurrences into a project that was soft-deleted (`projects.deleted = 1` because tasks still reference it), every other sync client fails to pull the projected `create_task` with `payload missing project_key`. The page is applied atomically, so the cursor never advances and the client is stuck until someone hand-edits the database.

The projected `create_task` payload (`occurrence_task_payload` in `operations/recurrence.rs`) only carries `project_id`, unlike a regular `create_task` which also has `project_key`/`project_name`/`project_prefix`. `ensure_project_for_payload` special-cases series payloads but only via `live_project_by_id`, so a deleted project misses the shortcut and falls through to the path that requires `project_key`.

## Fix

In `ensure_project_for_payload`, for payloads with a `series_id`:

- keep resolving live projects as before,
- also resolve through `project_id_aliases`,
- and accept a project that exists locally but is deleted — the originating client projected into that deleted project, so the receiving client now mirrors it instead of failing the page.

## Test

`recurrence_occurrence_into_deleted_project_syncs_to_other_clients` in `tests/cli_sync.rs` reproduces the scenario with two clients and a real sync server: create a daily series in `app`, delete `app` from the other client, complete the occurrence so the next one is projected into the deleted project, and sync. Without the fix the test fails with `payload missing project_key`; with the fix both clients converge (task count, project id, occurrences, no pending changes).

Also ran the full `cli_sync` suite, `aven-core` unit tests, `cargo fmt --check` and `cargo clippy --all-targets` locally (linux arm64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
