### PR TITLE
Detect Warp term for inline image previews

### DIFF
--- a/docs/src/content/docs/configuration.md
+++ b/docs/src/content/docs/configuration.md
@@ -137,9 +137,9 @@ All image attachment settings are optional. The defaults support normal use with
 | `auto` | Show previews in supported terminals outside tmux and labels everywhere else. This is the default. |
 | `on` | Show previews in supported terminals and enable tmux passthrough. |
 
-Aven uses the iTerm2 inline-image protocol in iTerm2 and the Kitty graphics protocol in Kitty, WezTerm, and Ghostty. Setting `on` helps these protocols pass through tmux, but cannot add image support to another terminal. Sixel-only terminals show text labels.
+Aven uses the iTerm2 inline-image protocol in iTerm2 and the Kitty graphics protocol in Kitty, WezTerm, Ghostty, and Warp. Setting `on` helps these protocols pass through tmux, but cannot add image support to another terminal. Sixel-only terminals show text labels.
 
-Detection uses terminal markers such as `TERM_PROGRAM`, `TERM`, `KITTY_WINDOW_ID`, `WEZTERM_PANE`, and `GHOSTTY_RESOURCES_DIR`. See [Image attachments](/tui/#image-attachments) for controls and [Troubleshoot image previews](/tips/#troubleshoot-image-previews) for setup help.
+Detection uses terminal markers such as `TERM_PROGRAM`, `TERM`, `KITTY_WINDOW_ID`, `WEZTERM_PANE`, `GHOSTTY_RESOURCES_DIR`, and `WARP_TERMINAL_SESSION_UUID`. See [Image attachments](/tui/#image-attachments) for controls and [Troubleshoot image previews](/tips/#troubleshoot-image-previews) for setup help.
 
 ### PNG optimization
 

--- a/docs/src/content/docs/tips.md
+++ b/docs/src/content/docs/tips.md
@@ -87,7 +87,7 @@ aven attachment get 7KQ9A1X4MV2P8D6R --json
 
 ### The terminal shows labels instead of previews
 
-Inline previews work in iTerm2, Kitty, WezTerm, and Ghostty. Other terminals, including Sixel-only terminals, show labels instead. In task detail, use `Tab` to focus a locally available image and press `Enter` or `o` to open it in the operating system's default viewer. Clicking the image label performs the same external open. You can also save a regular copy with `aven attachment get --output`.
+Inline previews work in iTerm2, Kitty, WezTerm, Ghostty, and Warp. Other terminals, including Sixel-only terminals, show labels instead. In task detail, use `Tab` to focus a locally available image and press `Enter` or `o` to open it in the operating system's default viewer. Clicking the image label performs the same external open. You can also save a regular copy with `aven attachment get --output`.
 
 Check the preview mode in `~/.config/aven/config.yaml`:
 
@@ -100,9 +100,9 @@ local:
 - `auto` shows previews in supported terminals outside tmux and labels inside tmux.
 - `on` also enables tmux passthrough for a supported outer terminal.
 
-Inside tmux, try `on` only when the outer terminal and tmux support the same image protocol. Aven uses the iTerm2 inline-image protocol in iTerm2 and the Kitty graphics protocol in Kitty, WezTerm, and Ghostty. See [Image previews](/configuration/#image-previews) for the complete setting behavior.
+Inside tmux, try `on` only when the outer terminal and tmux support the same image protocol. Aven uses the iTerm2 inline-image protocol in iTerm2 and the Kitty graphics protocol in Kitty, WezTerm, Ghostty, and Warp. See [Image previews](/configuration/#image-previews) for the complete setting behavior.
 
-For detection problems, check that the terminal exports its normal markers into the shell that launches Aven. Aven recognizes `TERM_PROGRAM`, `TERM`, `KITTY_WINDOW_ID`, `WEZTERM_PANE`, and `GHOSTTY_RESOURCES_DIR`.
+For detection problems, check that the terminal exports its normal markers into the shell that launches Aven. Aven recognizes `TERM_PROGRAM`, `TERM`, `KITTY_WINDOW_ID`, `WEZTERM_PANE`, `GHOSTTY_RESOURCES_DIR`, and `WARP_TERMINAL_SESSION_UUID`.
 
 ### The image is available but the preview still fails
 

--- a/src/tui/inline_images.rs
+++ b/src/tui/inline_images.rs
@@ -24,6 +24,7 @@ pub(crate) struct InlineImageTerminal<'a> {
     pub(crate) kitty_window_id: Option<&'a str>,
     pub(crate) wezterm_pane: Option<&'a str>,
     pub(crate) ghostty_resources_dir: Option<&'a str>,
+    pub(crate) warp_terminal_session_uuid: Option<&'a str>,
     pub(crate) in_tmux: bool,
 }
 
@@ -59,6 +60,7 @@ pub(crate) fn active_backend_from_env(config: InlineImagesConfig) -> InlineImage
     let kitty_window_id = std::env::var("KITTY_WINDOW_ID").ok();
     let wezterm_pane = std::env::var("WEZTERM_PANE").ok();
     let ghostty_resources_dir = std::env::var("GHOSTTY_RESOURCES_DIR").ok();
+    let warp_terminal_session_uuid = std::env::var("WARP_TERMINAL_SESSION_UUID").ok();
     let in_tmux = std::env::var_os("TMUX").is_some();
     active_backend(
         config,
@@ -68,6 +70,7 @@ pub(crate) fn active_backend_from_env(config: InlineImagesConfig) -> InlineImage
             kitty_window_id: kitty_window_id.as_deref(),
             wezterm_pane: wezterm_pane.as_deref(),
             ghostty_resources_dir: ghostty_resources_dir.as_deref(),
+            warp_terminal_session_uuid: warp_terminal_session_uuid.as_deref(),
             in_tmux,
         },
     )
@@ -81,12 +84,14 @@ fn active_protocol(terminal: InlineImageTerminal<'_>) -> Option<InlineImageProto
         term_program.eq_ignore_ascii_case("kitty")
             || term_program.eq_ignore_ascii_case("WezTerm")
             || term_program.eq_ignore_ascii_case("ghostty")
+            || term_program.eq_ignore_ascii_case("WarpTerminal")
     });
     if matches!(terminal.term, Some("xterm-kitty" | "xterm-ghostty"))
         || terminal.kitty_window_id.is_some()
         || kitty_term_program
         || terminal.wezterm_pane.is_some()
         || terminal.ghostty_resources_dir.is_some()
+        || terminal.warp_terminal_session_uuid.is_some()
     {
         return Some(InlineImageProtocol::Kitty);
     }
@@ -259,6 +264,14 @@ mod tests {
             self
         }
 
+        fn warp_terminal_session_uuid(
+            mut self,
+            warp_terminal_session_uuid: Option<&'a str>,
+        ) -> Self {
+            self.warp_terminal_session_uuid = warp_terminal_session_uuid;
+            self
+        }
+
         fn in_tmux(mut self, in_tmux: bool) -> Self {
             self.in_tmux = in_tmux;
             self
@@ -289,6 +302,9 @@ mod tests {
             terminal().term_program(Some("ghostty")),
             terminal().ghostty_resources_dir(Some("/Applications/Ghostty.app/Contents/Resources")),
             terminal().kitty_window_id(Some("3")),
+            terminal().term_program(Some("WarpTerminal")),
+            terminal().term_program(Some("warpterminal")),
+            terminal().warp_terminal_session_uuid(Some("00000000-0000-0000-0000-000000000000")),
         ] {
             assert_eq!(
                 active_backend(InlineImagesConfig::Auto, terminal),


### PR DESCRIPTION
## Problem

[Warp Terminal](https://www.warp.dev/terminal) implements the Kitty graphics protocol, but `active_protocol` in `src/tui/inline_images.rs` only recognizes iTerm2, Kitty, WezTerm, and Ghostty. In Warp the TUI always falls back to text labels, even with `local.inline_images: auto` or `on`, because detection returns `None` before the config is consulted.

Warp exports `TERM_PROGRAM=WarpTerminal` and `WARP_TERMINAL_SESSION_UUID` (the latter also survives Warp's ssh wrapper, where `TERM_PROGRAM` is typically lost).

## Fix

Add Warp to the Kitty branch of `active_protocol`, keyed on `TERM_PROGRAM=WarpTerminal` (case-insensitive, like the other `TERM_PROGRAM` checks) with `WARP_TERMINAL_SESSION_UUID` as the fallback marker. Same shape as the existing WezTerm and Ghostty entries. Detection only fires in Warp, so other terminals are unaffected.

Updated the supported-terminal and detection-marker lists in `configuration.md` and `tips.md` to match.

Precedent: pi merged the same detection in https://github.com/earendil-works/pi/pull/5841.

## Verified

Warp v0.2026.08.19.08.15.stable_01 on macOS, `inline_images: auto`, outside tmux:

- Chunked PNG transmit with image numbers and placement IDs renders the preview in task detail.
- Delete (`a=d,d=N`) clears the preview when leaving the task and on resize; nothing lingers.

Before this change the same setup showed the text label only. Forcing detection with `KITTY_WINDOW_ID=1` produced the identical result, which is what pointed at detection rather than rendering.

<img width="2922" height="1710" alt="CS 2026-08-28 at 03-46AM@2x" src="https://github.com/user-attachments/assets/8a0d7948-4228-4899-95fe-e6d5c5e5244f" />


## Tests

Added the Warp markers to `auto_uses_kitty_graphics_for_known_terminals`. `cargo test --lib inline_images` (16 passed), `cargo clippy --all-targets`, and `cargo fmt --check` are clean.

## Note on running the full suite locally

`App::new` calls `active_backend_from_env`, so two detail-mode mouse tests (`clicking_detail_markdown_link_opens_browser` and `detail_back_returns_from_epic_child_to_parent_detail`) depend on the terminal the test process runs in. They already fail on `main` when run from Ghostty (`TERM_PROGRAM=ghostty`) and pass with `TERM_PROGRAM` unset; this PR just adds Warp to that set. CI is unaffected.